### PR TITLE
Tests, bug fixes, and code quality improvements

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,21 @@
+name: Unit tests
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12.7"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: pytest tests/test_unit.py -v

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,6 @@
 name: Unit tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -178,5 +178,3 @@ cython_debug/
 
 AGENTS.md
 TODO.txt
-test/amici.txt
-test/An-introduction-to-neural-networks-for-beginners.pdf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,6 @@ The tool syncs local files into an AnythingLLM workspace. There are two distinct
 
 ## Known limitations / TODOs
 
-- Modified documents are detected (timestamp comparison) but re-upload is not yet implemented (prints "TODO: Upload document ...")
-- `remove_loaded_documents` appends `loaded_document.anythingllm_document_location` to `documents_to_unload`, then passes that to `database.remove_document` which deletes by `local_file_path` — so the DB record is never cleaned up after deletion
 - Embeddings are done one at a time with a 0.5s sleep to avoid overloading AnythingLLM
+- `embed_new_document` does not surface non-200 responses as a return value, so embedding failures are printed but not acted on by the caller
 - Supported file types: `txt`, `md`, `org`, `adoc`, `rst`, `html`, `docx`, `odt`, `odp`, `pdf`, `mbox`, `epub`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Setup
+
+```shell
+pyenv install 3.12.7
+pyenv local 3.12.7
+pyenv exec python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Running
+
+```shell
+python ingest_anythingllm_docs.py
+```
+
+Requires `~/.anythingllm-sync/config.yaml`:
+
+```yaml
+api-key: <key>
+workspace-slug: <slug>
+file-paths:
+  - /path/to/documents/
+directory-excludes:
+  - .obsidian
+file-excludes:
+  - .DS_Store
+```
+
+## Architecture
+
+The tool syncs local files into an AnythingLLM workspace. There are two distinct states a document can be in:
+
+1. **Loaded** — uploaded to AnythingLLM's document store (tracked in local SQLite DB at `~/.anythingllm-sync/uploaded-docs.db`)
+2. **Embedded** — ingested into the workspace vector store (queryable by the LLM)
+
+`ingest_anythingllm_docs.py` orchestrates a full sync cycle:
+1. Discover local files matching configured paths/extensions
+2. Upload new/modified files → record in SQLite DB
+3. Embed loaded-but-not-embedded documents into the workspace
+4. Unembed documents no longer present locally
+5. Delete documents from AnythingLLM's store that are no longer present locally
+
+`anythingllm_loader/anythingllm_api.py` — wraps the AnythingLLM REST API (assumed running at `http://localhost:3001`). Key distinction: `unload_document` calls `/v1/system/remove-documents` (deletes from store), while `unembed_document` calls `/api/v1/workspace/{slug}/update-embeddings` with `deletes` (removes from workspace only).
+
+`anythingllm_loader/database.py` — SQLite wrapper tracking the mapping from local file path → AnythingLLM document location (`custom-documents/<name>-<uuid>.json`).
+
+`anythingllm_loader/config.py` — loads `~/.anythingllm-sync/config.yaml`.
+
+## Known limitations / TODOs
+
+- Modified documents are detected (timestamp comparison) but re-upload is not yet implemented (prints "TODO: Upload document ...")
+- `remove_loaded_documents` appends `loaded_document.anythingllm_document_location` to `documents_to_unload`, then passes that to `database.remove_document` which deletes by `local_file_path` — so the DB record is never cleaned up after deletion
+- Embeddings are done one at a time with a 0.5s sleep to avoid overloading AnythingLLM
+- Supported file types: `txt`, `md`, `org`, `adoc`, `rst`, `html`, `docx`, `odt`, `odp`, `pdf`, `mbox`, `epub`

--- a/README.md
+++ b/README.md
@@ -1,96 +1,104 @@
-# AnythingLLM Document Loader
+# AnythingLLM Document Sync
 
-A Python utility for managing document ingestion into AnythingLLM workspaces. 
-This tool automates the process of uploading, embedding, and managing documents for use with AnythingLLM.
+A Python utility for syncing local documents into an AnythingLLM workspace.
+It scans configured directories, uploads new or modified files, embeds them into
+the workspace, and removes documents that have been deleted locally.
 
 ## Features
 
-- **Automatic Document Discovery**: Recursively scans directories for supported document types
-- **Smart Document Management**: Only uploads new or modified documents
-- **Document Tracking**: Maintains a local database to track document status
-- **Cleanup Functionality**: Removes documents from AnythingLLM that no longer exist locally
+- **Automatic document discovery**: Recursively scans directories for supported document types
+- **Smart sync**: Only uploads new or modified documents; skips unchanged ones
+- **Document tracking**: Maintains a local SQLite database to track uploaded files
+- **Cleanup**: Unembeds and removes documents from AnythingLLM when deleted locally
 - **Configurable**: Supports file and directory exclusions
+
+## Supported file types
+
+`txt`, `md`, `org`, `adoc`, `rst`, `html`, `docx`, `odt`, `odp`, `pdf`, `mbox`, `epub`
 
 ## Requirements
 
-- Tested with Python 3.12.7
-- AnythingLLM instance
-- Required Python packages:
-  - requests
-  - PyYAML
+- Python 3.12.7
+- AnythingLLM Desktop (or server) running locally at `http://localhost:3001`
+- `pyenv` and `sqlite` (macOS: `brew install pyenv sqlite`)
 
 ## Installation
 
-Instructions below are for macOS.
-
-1. Install prerequisites
-
 ```shell
-# Data about the files which have been uploaded is stored in an sqlite database
-brew install sqlite
-# Python virtual environments
-brew install pyenv
-```
-
-2. Create and activate a python virtual environment
-
-```shell
-pyenv install 3.12.7 
+pyenv install 3.12.7
 pyenv local 3.12.7
 pyenv exec python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
-```
-
-2. Install python libraries
-
-```shell
 pip install -r requirements.txt
 ```
 
 ## Configuration
 
-Create a configuration file in ~/.anythingllm-sync/config.yaml.
+Create `~/.anythingllm-sync/config.yaml`:
 
 ```yaml
-api-key: WFSDFD-ASDAFDFD-Q8M53TR-AAAAS48
-workspace-slug: aws
+api-key: YOUR-API-KEY
+workspace-slug: your-workspace
 file-paths:
- - /Users/username/Documents/
+  - /Users/username/Documents/
 directory-excludes:
- - .obsidian
+  - .obsidian
 file-excludes:
- - .DS_Store
+  - .DS_Store
 ```
 
-To fetch the API Key, from the AnythingLLM Desktop application:
-1. Click on the spanner icon at the bottom right of the left-hand navigation, to open settings
-2. Under the Tools heading, select Developer API
-3. Click on "Generate New API Key"
+**API key**: AnythingLLM Desktop → spanner icon (bottom right) → Developer API → Generate New API Key
 
-To fetch the workspace slug:
-1. From the AnythingLLM start screen, click the workspace in the left-hand navigation, and then click on the settings cog icon
-2. Click the "Vector Database" tab
-3. The "Vector database identifier" is the same as the workspace slug
+**Workspace slug**: Click workspace → settings cog → Vector Database tab → Vector database identifier
 
 ## Usage
-
-Run the main script to process documents:
 
 ```shell
 python ingest_anythingllm_docs.py
 ```
 
-The script will:
-1. Scan configured directories (configured as file-paths) for documents
-2. Upload new or modified documents to AnythingLLM.  The script stores a sqlite database in ~/.anythingllm-sync/uploaded-docs.db to keep a record of uploaded files.
-3. Embed documents that have been uploaded but not yet embedded
-4. Remove documents from AnythingLLM that no longer exist locally
+Each run:
+1. Scans `file-paths` for supported documents (respecting exclusions)
+2. Uploads new or modified documents to AnythingLLM
+3. Embeds uploaded-but-not-yet-embedded documents into the workspace
+4. Unembeds documents no longer present locally
+5. Removes unembedded documents from AnythingLLM's document store
+6. Cleans up the local tracking database
 
-## Project Structure
+Document upload state is tracked in `~/.anythingllm-sync/uploaded-docs.db` (SQLite).
 
-- `ingest_anythingllm_docs.py`: Main script for document processing
-- `anythingllm_loader/`: Package containing core functionality
-  - `anythingllm_api.py`: API client for AnythingLLM
-  - `config.py`: Configuration handling
-  - `database.py`: Local document tracking database
+## Running the tests
+
+**Unit tests** (no AnythingLLM instance required — all API calls are mocked):
+
+```shell
+pytest tests/test_unit.py -v
+```
+
+**Integration tests** (requires AnythingLLM running at `http://localhost:3001` and a valid `~/.anythingllm-sync/config.yaml`):
+
+```shell
+pytest tests/test_integration.py -v
+```
+
+Run all tests:
+
+```shell
+pytest tests/ -v
+```
+
+## Project structure
+
+```
+ingest_anythingllm_docs.py   Main script — orchestrates the sync cycle
+anythingllm_loader/
+  anythingllm_api.py         AnythingLLM REST API client
+  config.py                  Config file loader (~/.anythingllm-sync/config.yaml)
+  database.py                SQLite wrapper (~/.anythingllm-sync/uploaded-docs.db)
+tests/
+  test_unit.py               Unit tests (mocked API, no live instance needed)
+  test_integration.py        Integration tests (requires live AnythingLLM)
+docs/
+  openapi.json               AnythingLLM OpenAPI specification
+```

--- a/anythingllm_loader/anythingllm_api.py
+++ b/anythingllm_loader/anythingllm_api.py
@@ -46,13 +46,17 @@ class AnythingLLM:
             print(local_document_path + " is not a supported file type. Skipping.")
             return
 
-        with open(local_document_path, 'rb') as f:
-            response: Response = requests.post('http://localhost:3001/api/v1/document/upload', headers={
-                'accept': 'application/json',
-                'Authorization': 'Bearer ' + self.config.api_key
-            }, files={
-                'file': f
-            })
+        try:
+            with open(local_document_path, 'rb') as f:
+                response: Response = requests.post('http://localhost:3001/api/v1/document/upload', headers={
+                    'accept': 'application/json',
+                    'Authorization': 'Bearer ' + self.config.api_key
+                }, files={
+                    'file': f
+                })
+        except Exception as e:
+            print(f'Exception occurred while uploading {local_document_path}: {str(e)}')
+            return
 
         # Response looks like this
         # {
@@ -76,7 +80,7 @@ class AnythingLLM:
         #   ]
         # }
 
-        # throw an error if the response is not 200
+        # return None/False if the response is not 200
         if response.status_code != 200:
             print('Failed to upload document: ' + local_document_path + ": " + response.text)
             return
@@ -172,7 +176,7 @@ class AnythingLLM:
             print(f'Exception occurred while removing {document_to_unload}: {str(e)}')
             return False
 
-        # throw an error if the response is not 200
+        # return None/False if the response is not 200
         if response.status_code != 200:
             print('Failed to remove documents: ' + response.text)
             return False
@@ -205,7 +209,7 @@ class AnythingLLM:
                     "adds": [document_to_embed]
                 },
                 timeout=60)
-            # throw an error if the response is not 200
+            # return None/False if the response is not 200
             if response.status_code != 200:
                 print('Failed to embed documents: ' + response.text)
                 return
@@ -320,6 +324,6 @@ class AnythingLLM:
             print(f'Exception occurred while unembedding {document_to_unembed}: {str(e)}')
             return
 
-        # throw an error if the response is not 200
+        # return None/False if the response is not 200
         if response.status_code != 200:
             print('Failed to unembed documents: ' + response.text)

--- a/anythingllm_loader/anythingllm_api.py
+++ b/anythingllm_loader/anythingllm_api.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 import requests
 from requests import Response
@@ -47,12 +46,13 @@ class AnythingLLM:
             print(local_document_path + " is not a supported file type. Skipping.")
             return
 
-        response: Response = requests.post('http://localhost:3001/api/v1/document/upload', headers={
-            'accept': 'application/json',
-            'Authorization': 'Bearer ' + self.config.api_key
-        }, files={
-            'file': open(local_document_path, 'rb')
-        })
+        with open(local_document_path, 'rb') as f:
+            response: Response = requests.post('http://localhost:3001/api/v1/document/upload', headers={
+                'accept': 'application/json',
+                'Authorization': 'Bearer ' + self.config.api_key
+            }, files={
+                'file': f
+            })
 
         # Response looks like this
         # {
@@ -157,22 +157,21 @@ class AnythingLLM:
 
         print("Removing document: " + document_to_unload)
 
-        # Extract the excel spreadsheet name from the anythingllm_document_location
-        # Excel spreadsheet looks like this: aws-game-day-and-re-invent-recap-sign-up-(responses).xlsx-2ce4/sheet-Form-responses-1.json
-        # If the document to unload is an excel spreadsheet, then we need to remove the entire spreadsheet
-        if re.search(r".*\.xlsx-\w+\/sheet.*", document_to_unload):
-            document_to_unload = document_to_unload.split('/')[-2]
-
         # Delete the document.
-        response: Response = requests.delete('http://localhost:3001/api/v1/system/remove-documents',
-                                           headers={
-                                               'accept': 'application/json',
-                                               'Content-Type': 'application/json',
-                                               'Authorization': 'Bearer ' + self.config.api_key
-                                           }, json={
-                "names": [document_to_unload]
-            },
-                                           timeout=60)
+        try:
+            response: Response = requests.delete('http://localhost:3001/api/v1/system/remove-documents',
+                                               headers={
+                                                   'accept': 'application/json',
+                                                   'Content-Type': 'application/json',
+                                                   'Authorization': 'Bearer ' + self.config.api_key
+                                               }, json={
+                    "names": [document_to_unload]
+                },
+                                               timeout=60)
+        except Exception as e:
+            print(f'Exception occurred while removing {document_to_unload}: {str(e)}')
+            return False
+
         # throw an error if the response is not 200
         if response.status_code != 200:
             print('Failed to remove documents: ' + response.text)
@@ -306,16 +305,21 @@ class AnythingLLM:
         # }'
 
         # Embed the documents
-        response: Response = requests.post(
-            'http://localhost:3001/api/v1/workspace/' + self.config.workspace_slug + '/update-embeddings',
-            headers={
-                'accept': 'application/json',
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer ' + self.config.api_key
-            }, json={
-                "deletes": [document_to_unembed]
-            },
-            timeout=60)
+        try:
+            response: Response = requests.post(
+                'http://localhost:3001/api/v1/workspace/' + self.config.workspace_slug + '/update-embeddings',
+                headers={
+                    'accept': 'application/json',
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Bearer ' + self.config.api_key
+                }, json={
+                    "deletes": [document_to_unembed]
+                },
+                timeout=60)
+        except Exception as e:
+            print(f'Exception occurred while unembedding {document_to_unembed}: {str(e)}')
+            return
+
         # throw an error if the response is not 200
         if response.status_code != 200:
             print('Failed to unembed documents: ' + response.text)

--- a/anythingllm_loader/database.py
+++ b/anythingllm_loader/database.py
@@ -26,7 +26,6 @@ class DocumentDatabase:
 
         """Initialize the database and create tables if they don't exist."""
         if not os.path.exists(DATABASE_FILENAME):
-            conn = None
             try:
                 with sqlite3.connect(DATABASE_FILENAME) as conn:
                     cursor = conn.cursor()
@@ -44,9 +43,6 @@ class DocumentDatabase:
             except sqlite3.Error as e:
                 print(f"Error creating database: {e}")
                 return False
-            finally:
-                if conn:
-                    conn.close()
         return True
 
     @staticmethod

--- a/anythingllm_loader/database.py
+++ b/anythingllm_loader/database.py
@@ -26,15 +26,16 @@ class DocumentDatabase:
 
         """Initialize the database and create tables if they don't exist."""
         if not os.path.exists(DATABASE_FILENAME):
+            conn = None
             try:
                 with sqlite3.connect(DATABASE_FILENAME) as conn:
                     cursor = conn.cursor()
                     cursor.execute('''
                         CREATE TABLE documents (
-                            id INTEGER PRIMARY KEY, 
-                            local_file_path TEXT, 
+                            id INTEGER PRIMARY KEY,
+                            local_file_path TEXT,
                             upload_timestamp DATETIME,
-                            anythingllm_document_location TEXT, 
+                            anythingllm_document_location TEXT,
                             content TEXT
                         )
                     ''')

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -843,7 +843,7 @@
         "tags": [
           "Documents"
         ],
-        "description": "Upload a new file to AnythingLLM to be parsed and prepared for embedding.",
+        "description": "Upload a new file to AnythingLLM to be parsed and prepared for embedding, with optional metadata.",
         "parameters": [],
         "responses": {
           "200": {
@@ -865,7 +865,7 @@
                         "description": "Unknown",
                         "docSource": "a text file uploaded by the user.",
                         "chunkSource": "anythingllm.txt",
-                        "published": "1/16/2024, 3:07:00 PM",
+                        "published": "1/16/2024, 3:07:00 PM",
                         "wordCount": 93,
                         "token_count_estimate": 115
                       }
@@ -890,6 +890,9 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity"
+          },
           "500": {
             "description": "Internal Server Error"
           }
@@ -900,12 +903,147 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "type": "string",
-                "format": "binary",
+                "type": "object",
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
-                    "format": "binary"
+                    "format": "binary",
+                    "description": "The file to upload"
+                  },
+                  "addToWorkspaces": {
+                    "type": "string",
+                    "description": "comma-separated text-string of workspace slugs to embed the document into post-upload. eg: workspace1,workspace2"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Key:Value pairs of metadata to attach to the document in JSON Object format. Only specific keys are allowed - see example.",
+                    "example": {
+                      "title": "Custom Title",
+                      "docAuthor": "Author Name",
+                      "description": "A brief description",
+                      "docSource": "Source of the document"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/document/upload/{folderName}": {
+      "post": {
+        "tags": [
+          "Documents"
+        ],
+        "description": "Upload a new file to a specific folder in AnythingLLM to be parsed and prepared for embedding. If the folder does not exist, it will be created.",
+        "parameters": [
+          {
+            "name": "folderName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Target folder path (defaults to 'custom-documents' if not provided)",
+            "example": "my-folder"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "success": true,
+                    "error": null,
+                    "documents": [
+                      {
+                        "location": "custom-documents/anythingllm.txt-6e8be64c-c162-4b43-9997-b068c0071e8b.json",
+                        "name": "anythingllm.txt-6e8be64c-c162-4b43-9997-b068c0071e8b.json",
+                        "url": "file://Users/tim/Documents/anything-llm/collector/hotdir/anythingllm.txt",
+                        "title": "anythingllm.txt",
+                        "docAuthor": "Unknown",
+                        "description": "Unknown",
+                        "docSource": "a text file uploaded by the user.",
+                        "chunkSource": "anythingllm.txt",
+                        "published": "1/16/2024, 3:07:00 PM",
+                        "wordCount": 93,
+                        "token_count_estimate": 115
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "success": false,
+                    "error": "Document processing API is not online. Document will not be processed automatically."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "description": "File to be uploaded, with optional metadata.",
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "The file to upload"
+                  },
+                  "addToWorkspaces": {
+                    "type": "string",
+                    "description": "comma-separated text-string of workspace slugs to embed the document into post-upload. eg: workspace1,workspace2"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Key:Value pairs of metadata to attach to the document in JSON Object format. Only specific keys are allowed - see example.",
+                    "example": {
+                      "title": "Custom Title",
+                      "docAuthor": "Author Name",
+                      "description": "A brief description",
+                      "docSource": "Source of the document"
+                    }
                   }
                 }
               }
@@ -919,7 +1057,7 @@
         "tags": [
           "Documents"
         ],
-        "description": "Upload a valid URL for AnythingLLM to scrape and prepare for embedding.",
+        "description": "Upload a valid URL for AnythingLLM to scrape and prepare for embedding. Optionally, specify a comma-separated list of workspace slugs to embed the document into post-upload.",
         "parameters": [],
         "responses": {
           "200": {
@@ -940,7 +1078,7 @@
                         "description": "No description found.",
                         "docSource": "URL link uploaded by the user.",
                         "chunkSource": "https:anythingllm.com.html",
-                        "published": "1/16/2024, 3:46:33 PM",
+                        "published": "1/16/2024, 3:46:33 PM",
                         "wordCount": 252,
                         "pageContent": "AnythingLLM is the best....",
                         "token_count_estimate": 447,
@@ -967,19 +1105,33 @@
               }
             }
           },
+          "422": {
+            "description": "Unprocessable Entity"
+          },
           "500": {
             "description": "Internal Server Error"
           }
         },
         "requestBody": {
-          "description": "Link of web address to be scraped.",
+          "description": "Link of web address to be scraped and optionally a comma-separated list of workspace slugs to embed the document into post-upload, and optional metadata.",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "example": {
-                  "link": "https://anythingllm.com"
+                  "link": "https://anythingllm.com",
+                  "addToWorkspaces": "workspace1,workspace2",
+                  "scraperHeaders": {
+                    "Authorization": "Bearer token123",
+                    "My-Custom-Header": "value"
+                  },
+                  "metadata": {
+                    "title": "Custom Title",
+                    "docAuthor": "Author Name",
+                    "description": "A brief description",
+                    "docSource": "Source of the document"
+                  }
                 }
               }
             }
@@ -1013,7 +1165,7 @@
                         "description": "No description found.",
                         "docSource": "My custom description set during upload",
                         "chunkSource": "no chunk source specified",
-                        "published": "1/16/2024, 3:46:33 PM",
+                        "published": "1/16/2024, 3:46:33 PM",
                         "wordCount": 252,
                         "pageContent": "AnythingLLM is the best....",
                         "token_count_estimate": 447,
@@ -1056,6 +1208,7 @@
                 "type": "object",
                 "example": {
                   "textContent": "This is the raw text that will be saved as a document in AnythingLLM.",
+                  "addToWorkspaces": "workspace1,workspace2",
                   "metadata": {
                     "title": "This key is required. See in /server/endpoints/api/document/index.js:287",
                     "keyOne": "valueOne",
@@ -1102,6 +1255,76 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/v1/documents/folder/{folderName}": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "description": "Get all documents stored in a specific folder.",
+        "parameters": [
+          {
+            "name": "folderName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the folder to retrieve documents from"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "folder": "custom-documents",
+                    "documents": [
+                      {
+                        "name": "document1.json",
+                        "type": "file",
+                        "cached": false,
+                        "pinnedWorkspaces": [],
+                        "watched": false,
+                        "more": "data"
+                      },
+                      {
+                        "name": "document2.json",
+                        "type": "file",
+                        "cached": false,
+                        "pinnedWorkspaces": [],
+                        "watched": false,
+                        "more": "data"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "description": "OK"
           },
           "403": {
             "description": "Forbidden",
@@ -1351,6 +1574,66 @@
                 "type": "string",
                 "example": {
                   "name": "new-folder"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/document/remove-folder": {
+      "delete": {
+        "tags": [
+          "Documents"
+        ],
+        "description": "Remove a folder and all its contents from the documents storage directory.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "success": true,
+                    "message": "Folder removed successfully"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "requestBody": {
+          "description": "Name of the folder to remove.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "example": "my-folder"
+                  }
                 }
               }
             }
@@ -2032,21 +2315,27 @@
           }
         },
         "requestBody": {
-          "description": "Send a prompt to the workspace and the type of conversation (query or chat).<br/><b>Query:</b> Will not use LLM unless there are relevant sources from vectorDB & does not recall chat history.<br/><b>Chat:</b> Uses LLM general knowledge w/custom embeddings to produce output, uses rolling chat history.",
+          "description": "Send a prompt to the workspace and the type of conversation (automatic, query or chat).<br/><b>Query:</b> Will not use LLM unless there are relevant sources from vectorDB & does not recall chat history.<br/><b>Automatic:</b> Will use tool-calling if the provider supports native tool calling without needing to invoke @agent.<br/><b>Chat:</b> Uses LLM general knowledge w/custom embeddings to produce output, uses rolling chat history.<br/><b>Attachments:</b> Can include images and documents.<br/><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Document attachments:</b> must have the mime type <code>application/anythingllm-document</code> - otherwise it will be passed to the LLM as an image and may fail to process. This uses the built-in document processor to first parse the document to text before injecting it into the context window.",
           "required": true,
           "content": {
             "application/json": {
               "example": {
                 "message": "What is AnythingLLM?",
-                "mode": "query | chat",
+                "mode": "automatic | query | chat",
                 "sessionId": "identifier-to-partition-chats-by-external-id",
                 "attachments": [
                   {
                     "name": "image.png",
                     "mime": "image/png",
                     "contentString": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
+                  },
+                  {
+                    "name": "this is a document.pdf",
+                    "mime": "application/anythingllm-document",
+                    "contentString": "data:application/pdf;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                   }
-                ]
+                ],
+                "reset": false
               }
             }
           }
@@ -2134,21 +2423,27 @@
           }
         },
         "requestBody": {
-          "description": "Send a prompt to the workspace and the type of conversation (query or chat).<br/><b>Query:</b> Will not use LLM unless there are relevant sources from vectorDB & does not recall chat history.<br/><b>Chat:</b> Uses LLM general knowledge w/custom embeddings to produce output, uses rolling chat history.",
+          "description": "Send a prompt to the workspace and the type of conversation (automatic, query or chat).<br/><b>Query:</b> Will not use LLM unless there are relevant sources from vectorDB & does not recall chat history.<br/><b>Automatic:</b> Will use tool-calling if the provider supports native tool calling without needing to invoke @agent.<br/><b>Chat:</b> Uses LLM general knowledge w/custom embeddings to produce output, uses rolling chat history.<br/><b>Attachments:</b> Can include images and documents.<br/><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Document attachments:</b> must have the mime type <code>application/anythingllm-document</code> - otherwise it will be passed to the LLM as an image and may fail to process. This uses the built-in document processor to first parse the document to text before injecting it into the context window.",
           "required": true,
           "content": {
             "application/json": {
               "example": {
                 "message": "What is AnythingLLM?",
-                "mode": "query | chat",
+                "mode": "automatic | query | chat",
                 "sessionId": "identifier-to-partition-chats-by-external-id",
                 "attachments": [
                   {
                     "name": "image.png",
                     "mime": "image/png",
                     "contentString": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
+                  },
+                  {
+                    "name": "this is a document.pdf",
+                    "mime": "application/anythingllm-document",
+                    "contentString": "data:application/pdf;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                   }
-                ]
+                ],
+                "reset": false
               }
             }
           }
@@ -2909,7 +3204,8 @@
                     "mime": "image/png",
                     "contentString": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                   }
-                ]
+                ],
+                "reset": false
               }
             }
           }
@@ -3020,8 +3316,14 @@
                     "name": "image.png",
                     "mime": "image/png",
                     "contentString": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
+                  },
+                  {
+                    "name": "this is a document.pdf",
+                    "mime": "application/anythingllm-document",
+                    "contentString": "data:application/pdf;base64,iVBORw0KGgoAAAANSUhEUgAA..."
                   }
-                ]
+                ],
+                "reset": false
               }
             }
           }
@@ -3158,22 +3460,19 @@
                 "schema": {
                   "type": "object",
                   "example": {
-                    "models": [
+                    "object": "list",
+                    "data": [
                       {
-                        "name": "Sample workspace",
-                        "model": "sample-workspace",
-                        "llm": {
-                          "provider": "ollama",
-                          "model": "llama3:8b"
-                        }
+                        "id": "model-id-0",
+                        "object": "model",
+                        "created": 1686935002,
+                        "owned_by": "organization-owner"
                       },
                       {
-                        "name": "Second workspace",
-                        "model": "workspace-2",
-                        "llm": {
-                          "provider": "openai",
-                          "model": "gpt-3.5-turbo"
-                        }
+                        "id": "model-id-1",
+                        "object": "model",
+                        "created": 1686935002,
+                        "owned_by": "organization-owner"
                       }
                     ]
                   }
@@ -3307,7 +3606,7 @@
           "content": {
             "application/json": {
               "example": {
-                "inputs": [
+                "input": [
                   "This is my first string to embed",
                   "This is my second string to embed"
                 ],
@@ -3571,6 +3870,226 @@
           },
           "404": {
             "description": "Embed or session not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/v1/embed/new": {
+      "post": {
+        "tags": [
+          "Embed"
+        ],
+        "description": "Create a new embed configuration",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "embed": {
+                      "id": 1,
+                      "uuid": "embed-uuid-1",
+                      "enabled": true,
+                      "chat_mode": "chat",
+                      "allowlist_domains": [
+                        "example.com"
+                      ],
+                      "allow_model_override": false,
+                      "allow_temperature_override": false,
+                      "allow_prompt_override": false,
+                      "max_chats_per_day": 100,
+                      "max_chats_per_session": 10,
+                      "createdAt": "2023-04-01T12:00:00Z",
+                      "workspace_slug": "workspace-slug-1"
+                    },
+                    "error": null
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workspace not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "requestBody": {
+          "description": "JSON object containing embed configuration details",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "example": {
+                  "workspace_slug": "workspace-slug-1",
+                  "chat_mode": "chat",
+                  "allowlist_domains": [
+                    "example.com"
+                  ],
+                  "allow_model_override": false,
+                  "allow_temperature_override": false,
+                  "allow_prompt_override": false,
+                  "max_chats_per_day": 100,
+                  "max_chats_per_session": 10
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/embed/{embedUuid}": {
+      "post": {
+        "tags": [
+          "Embed"
+        ],
+        "description": "Update an existing embed configuration",
+        "parameters": [
+          {
+            "name": "embedUuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "UUID of the embed to update"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "success": true,
+                    "error": null
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Embed not found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "requestBody": {
+          "description": "JSON object containing embed configuration updates",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "example": {
+                  "enabled": true,
+                  "chat_mode": "chat",
+                  "allowlist_domains": [
+                    "example.com"
+                  ],
+                  "allow_model_override": false,
+                  "allow_temperature_override": false,
+                  "allow_prompt_override": false,
+                  "max_chats_per_day": 100,
+                  "max_chats_per_session": 10
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Embed"
+        ],
+        "description": "Delete an existing embed configuration",
+        "parameters": [
+          {
+            "name": "embedUuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "UUID of the embed to delete"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "success": true,
+                    "error": null
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidAPIKey"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Embed not found"
           },
           "500": {
             "description": "Internal Server Error"

--- a/ingest_anythingllm_docs.py
+++ b/ingest_anythingllm_docs.py
@@ -55,7 +55,7 @@ def upload_new_documents(anything_llm: AnythingLLM, database: DocumentDatabase, 
                         break
                     else:
                         print('Failed to remove old version of document from AnythingLLM: ' + local_document)
-                        document_loaded = True
+                        document_loaded = False
                         break
                 else:
                     document_loaded = True
@@ -106,6 +106,7 @@ def remove_embedded_documents(anything_llm: AnythingLLM, local_documents: list, 
         if embedded_document_local_path is None:
             # If the document path isn't in the database of local files, then delete it
             documents_to_unembed.append(embedded_document)
+            continue
 
         embedded_document_found_locally = False
         for local_document in local_documents:
@@ -134,11 +135,11 @@ def remove_loaded_documents(anything_llm: AnythingLLM, database: DocumentDatabas
 
         if not document_present_locally:
             # If the document path isn't in the database of local files, then delete it
-            documents_to_unload.append(loaded_document.anythingllm_document_location)
+            documents_to_unload.append(loaded_document)
 
     for document_to_unload in documents_to_unload:
-        if anything_llm.unload_document(document_to_unload):
-            database.remove_document(document_to_unload)
+        if anything_llm.unload_document(document_to_unload.anythingllm_document_location):
+            database.remove_document(document_to_unload.local_file_path)
 
 
 def main():

--- a/ingest_anythingllm_docs.py
+++ b/ingest_anythingllm_docs.py
@@ -37,109 +37,64 @@ def fetch_local_documents(config: AnythingLLMConfig):
 def upload_new_documents(anything_llm: AnythingLLM, database: DocumentDatabase, local_documents: list[str],
                          loaded_documents: list[AnythingLLMDocument]):
 
-    # compare the list of local documents with embedded documents to find the local documents that need embedding
+    loaded_by_path = {doc.local_file_path: doc for doc in loaded_documents}
+
     for local_document in local_documents:
-        # local_document is a file path string
-
-        document_loaded = False
         local_document_modified_timestamp = datetime.fromtimestamp(pathlib.Path(local_document).stat().st_mtime, tz=timezone.utc)
-        for loaded_document in loaded_documents:
-            if loaded_document.local_file_path == local_document:
+        loaded_document = loaded_by_path.get(local_document)
 
-                # if the date of the file is after the time that the loaded_document.upload_timestamp the load again
-                if int(local_document_modified_timestamp.strftime('%Y%m%d%H%M%S')) > int(
-                        loaded_document.upload_timestamp.strftime('%Y%m%d%H%M%S')):
-                    # Remove old version from AnythingLLM before uploading the new one
-                    if anything_llm.unload_document(loaded_document.anythingllm_document_location):
-                        database.remove_document(loaded_document.local_file_path)
-                        break
-                    else:
-                        print('Failed to remove old version of document from AnythingLLM: ' + local_document)
-                        document_loaded = False
-                        break
+        if loaded_document is not None:
+            # if the date of the file is after the time that the loaded_document.upload_timestamp the load again
+            if int(local_document_modified_timestamp.strftime('%Y%m%d%H%M%S')) > int(
+                    loaded_document.upload_timestamp.strftime('%Y%m%d%H%M%S')):
+                # Remove old version from AnythingLLM before uploading the new one
+                if anything_llm.unload_document(loaded_document.anythingllm_document_location):
+                    database.remove_document(loaded_document.local_file_path)
                 else:
-                    document_loaded = True
-                    break
+                    print('Failed to remove old version of document from AnythingLLM: ' + local_document)
+                # fall through to re-upload regardless of whether unload succeeded
+            else:
+                continue  # file unchanged, skip upload
 
-        if not document_loaded:
-            # upload the document
-            anything_llm_response = anything_llm.upload_document(local_document)
-            if anything_llm_response is not None:
-                database.add_document(AnythingLLMDocument(local_document, local_document_modified_timestamp,
-                                                          anything_llm_response['location'], json.dumps(anything_llm_response)
-                ))
+        # upload the document
+        anything_llm_response = anything_llm.upload_document(local_document)
+        if anything_llm_response is not None:
+            database.add_document(AnythingLLMDocument(local_document, local_document_modified_timestamp,
+                                                      anything_llm_response['location'], json.dumps(anything_llm_response)
+            ))
 
 
 def embed_new_documents(anything_llm: AnythingLLM, loaded_documents: list[AnythingLLMDocument], embedded_documents: list):
-    documents_to_embed = []
-
-    # Work out which documents are loaded but not yet embedded
-    for loaded_document in loaded_documents:
-        document_embedded = False
-        for embedded_document in embedded_documents:
-            if embedded_document == loaded_document.anythingllm_document_location:
-                document_embedded = True
-                break
-
-        if not document_embedded:
-            documents_to_embed.append(loaded_document.anythingllm_document_location)
+    embedded_set = set(embedded_documents)
 
     # embedding one at a time as larger batches seem to max out CPU
-    for document_to_embed in documents_to_embed:
-        anything_llm.embed_new_document(document_to_embed)
+    for loaded_document in loaded_documents:
+        if loaded_document.anythingllm_document_location not in embedded_set:
+            anything_llm.embed_new_document(loaded_document.anythingllm_document_location)
 
 
 def remove_embedded_documents(anything_llm: AnythingLLM, local_documents: list, loaded_documents: list[AnythingLLMDocument],
                               embedded_documents: list):
-    documents_to_unembed = []
+    local_path_by_location = {doc.anythingllm_document_location: doc.local_file_path for doc in loaded_documents}
+    local_documents_set = set(local_documents)
 
     for embedded_document in embedded_documents:
         # embedded_document is the loaded path:
         # "custom-documents/How-To.md-750a5515-ed82-4c2c-96b7-583463bab449.json"
+        local_path = local_path_by_location.get(embedded_document)
 
-        embedded_document_local_path = None
-        for loaded_document in loaded_documents:
-            if loaded_document.anythingllm_document_location == embedded_document:
-                embedded_document_local_path = loaded_document.local_file_path
-                break
-
-        if embedded_document_local_path is None:
-            # If the document path isn't in the database of local files, then delete it
-            documents_to_unembed.append(embedded_document)
-            continue
-
-        embedded_document_found_locally = False
-        for local_document in local_documents:
-            if embedded_document_local_path == local_document:
-                embedded_document_found_locally = True
-                break
-
-        if not embedded_document_found_locally:
-            documents_to_unembed.append(embedded_document)
-
-    for document_to_unembed in documents_to_unembed:
-        anything_llm.unembed_document(document_to_unembed)
+        if local_path is None or local_path not in local_documents_set:
+            anything_llm.unembed_document(embedded_document)
 
 
 def remove_loaded_documents(anything_llm: AnythingLLM, database: DocumentDatabase, local_documents: list,
                             loaded_documents: list[AnythingLLMDocument]):
-    documents_to_unload = []
+    local_documents_set = set(local_documents)
 
     for loaded_document in loaded_documents:
-        document_present_locally = False
-
-        for local_document in local_documents:
-            if loaded_document.local_file_path == local_document:
-                document_present_locally = True
-                break
-
-        if not document_present_locally:
-            # If the document path isn't in the database of local files, then delete it
-            documents_to_unload.append(loaded_document)
-
-    for document_to_unload in documents_to_unload:
-        if anything_llm.unload_document(document_to_unload.anythingllm_document_location):
-            database.remove_document(document_to_unload.local_file_path)
+        if loaded_document.local_file_path not in local_documents_set:
+            if anything_llm.unload_document(loaded_document.anythingllm_document_location):
+                database.remove_document(loaded_document.local_file_path)
 
 
 def main():

--- a/ingest_anythingllm_docs.py
+++ b/ingest_anythingllm_docs.py
@@ -58,7 +58,7 @@ def upload_new_documents(anything_llm: AnythingLLM, database: DocumentDatabase, 
                         document_loaded = False
                         break
                 else:
-                    document_loaded = False
+                    document_loaded = True
                     break
 
         if not document_loaded:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 PyYAML
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,276 @@
+"""
+Integration tests against a running local AnythingLLM instance.
+
+Requires ~/.anythingllm-sync/config.yaml to be present and AnythingLLM
+to be running at http://localhost:3001.
+
+Run with: pytest tests/test_integration.py -v
+"""
+
+import os
+import time
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from anythingllm_loader.config import AnythingLLMConfig
+from anythingllm_loader.anythingllm_api import AnythingLLM
+from anythingllm_loader.database import DocumentDatabase, AnythingLLMDocument
+from ingest_anythingllm_docs import (
+    upload_new_documents,
+    embed_new_documents,
+    remove_embedded_documents,
+    remove_loaded_documents,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def config():
+    return AnythingLLMConfig.load_config()
+
+
+@pytest.fixture(scope="module")
+def api(config):
+    client = AnythingLLM(config)
+    assert client.authenticate(), (
+        "Could not authenticate with AnythingLLM. "
+        "Check that AnythingLLM is running and ~/.anythingllm-sync/config.yaml is correct."
+    )
+    return client
+
+
+@pytest.fixture
+def test_file(tmp_path):
+    """A temporary text file to use as a test document."""
+    f = tmp_path / "anythingllm_integration_test.txt"
+    f.write_text("This is an integration test document for AnythingLLM.")
+    return f
+
+
+@pytest.fixture
+def db(tmp_path):
+    """A fresh temporary database, isolated from the real one."""
+    db_path = tmp_path / "test.db"
+    with patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        database = DocumentDatabase()
+        database.initialize_database()
+        yield database
+
+
+@pytest.fixture
+def uploaded(api, test_file):
+    """Upload a document and clean it up after the test regardless of outcome."""
+    result = api.upload_document(str(test_file))
+    assert result is not None, f"Failed to upload {test_file}"
+    yield result
+    api.unembed_document(result["location"])
+    time.sleep(0.5)
+    api.unload_document(result["location"])
+
+
+# ---------------------------------------------------------------------------
+# API-level tests
+# ---------------------------------------------------------------------------
+
+def test_authenticate(api):
+    assert api.authenticate()
+
+
+def test_upload_document(api, test_file):
+    result = api.upload_document(str(test_file))
+    assert result is not None
+    assert "location" in result
+    assert result["location"].startswith("custom-documents/")
+
+    api.unload_document(result["location"])
+
+
+def test_upload_empty_file_returns_none(api, tmp_path):
+    empty = tmp_path / "empty.txt"
+    empty.write_text("")
+    assert api.upload_document(str(empty)) is None
+
+
+def test_upload_unsupported_type_returns_none(api, tmp_path):
+    unsupported = tmp_path / "file.xyz"
+    unsupported.write_text("content")
+    assert api.upload_document(str(unsupported)) is None
+
+
+def test_uploaded_document_appears_in_loaded_list(api, uploaded):
+    loaded = api.fetch_loaded_documents_from_anythingllm()
+    # fetch_loaded_documents_from_anythingllm returns filenames without the
+    # custom-documents/ prefix; reconstruct for comparison
+    loaded_locations = {f"custom-documents/{name}" for name in loaded}
+    assert uploaded["location"] in loaded_locations
+
+
+def test_embed_document(api, uploaded):
+    location = uploaded["location"]
+
+    api.embed_new_document(location)
+    time.sleep(1)
+
+    embedded = api.fetch_embedded_workspace_documents()
+    assert location in embedded
+
+    api.unembed_document(location)
+    time.sleep(0.5)
+
+
+def test_unembed_document(api, uploaded):
+    location = uploaded["location"]
+
+    api.embed_new_document(location)
+    time.sleep(1)
+    assert location in api.fetch_embedded_workspace_documents()
+
+    api.unembed_document(location)
+    time.sleep(1)
+    assert location not in api.fetch_embedded_workspace_documents()
+
+
+def test_unload_document(api, test_file):
+    result = api.upload_document(str(test_file))
+    assert result is not None
+
+    assert api.unload_document(result["location"])
+
+    loaded = api.fetch_loaded_documents_from_anythingllm()
+    loaded_locations = {f"custom-documents/{name}" for name in loaded}
+    assert result["location"] not in loaded_locations
+
+
+# ---------------------------------------------------------------------------
+# Sync logic tests
+# ---------------------------------------------------------------------------
+
+def test_sync_uploads_new_document(api, db, test_file):
+    local_docs = [str(test_file)]
+
+    upload_new_documents(api, db, local_docs, db.get_documents())
+
+    saved = db.get_documents()
+    assert len(saved) == 1
+    assert saved[0].local_file_path == str(test_file)
+    assert saved[0].anythingllm_document_location.startswith("custom-documents/")
+
+    api.unload_document(saved[0].anythingllm_document_location)
+
+
+def test_sync_skips_unchanged_document(api, db, test_file):
+    local_docs = [str(test_file)]
+
+    upload_new_documents(api, db, local_docs, db.get_documents())
+    first_upload = db.get_documents()
+    assert len(first_upload) == 1
+    original_location = first_upload[0].anythingllm_document_location
+
+    # Second sync — file unchanged, should not re-upload
+    upload_new_documents(api, db, local_docs, db.get_documents())
+    second_upload = db.get_documents()
+    assert len(second_upload) == 1
+    assert second_upload[0].anythingllm_document_location == original_location
+
+    api.unload_document(original_location)
+
+
+def test_sync_reuploads_modified_document(api, db, test_file):
+    local_docs = [str(test_file)]
+
+    # Initial upload
+    upload_new_documents(api, db, local_docs, db.get_documents())
+    saved = db.get_documents()
+    assert len(saved) == 1
+    original_location = saved[0].anythingllm_document_location
+
+    # Modify the file and push its mtime into the future
+    test_file.write_text("Modified content.")
+    future_mtime = time.time() + 10
+    os.utime(test_file, (future_mtime, future_mtime))
+
+    # Second sync — should remove old version and re-upload
+    upload_new_documents(api, db, local_docs, db.get_documents())
+    saved = db.get_documents()
+    assert len(saved) == 1
+    assert saved[0].anythingllm_document_location != original_location
+
+    # Original should be gone from AnythingLLM
+    loaded = api.fetch_loaded_documents_from_anythingllm()
+    loaded_locations = {f"custom-documents/{name}" for name in loaded}
+    assert original_location not in loaded_locations
+
+    api.unload_document(saved[0].anythingllm_document_location)
+
+
+def test_sync_embeds_loaded_documents(api, db, test_file):
+    local_docs = [str(test_file)]
+
+    upload_new_documents(api, db, local_docs, db.get_documents())
+    loaded = db.get_documents()
+    location = loaded[0].anythingllm_document_location
+
+    embed_new_documents(api, loaded, api.fetch_embedded_workspace_documents())
+    time.sleep(1)
+
+    assert location in api.fetch_embedded_workspace_documents()
+
+    api.unembed_document(location)
+    time.sleep(0.5)
+    api.unload_document(location)
+
+
+def test_sync_removes_document_deleted_locally(api, db, test_file):
+    local_docs = [str(test_file)]
+
+    # Upload and embed
+    upload_new_documents(api, db, local_docs, db.get_documents())
+    loaded = db.get_documents()
+    location = loaded[0].anythingllm_document_location
+
+    embed_new_documents(api, loaded, api.fetch_embedded_workspace_documents())
+    time.sleep(1)
+    assert location in api.fetch_embedded_workspace_documents()
+
+    # Simulate local deletion by passing empty local_docs
+    embedded = api.fetch_embedded_workspace_documents()
+    remove_embedded_documents(api, [], db.get_documents(), embedded)
+    time.sleep(1)
+    assert location not in api.fetch_embedded_workspace_documents()
+
+    remove_loaded_documents(api, db, [], db.get_documents())
+    assert db.get_documents() == []
+
+    loaded_in_llm = api.fetch_loaded_documents_from_anythingllm()
+    loaded_locations = {f"custom-documents/{name}" for name in loaded_in_llm}
+    assert location not in loaded_locations
+
+
+def test_sync_does_not_embed_already_embedded_document(api, db, test_file):
+    local_docs = [str(test_file)]
+
+    upload_new_documents(api, db, local_docs, db.get_documents())
+    loaded = db.get_documents()
+    location = loaded[0].anythingllm_document_location
+
+    # Embed once
+    embed_new_documents(api, loaded, api.fetch_embedded_workspace_documents())
+    time.sleep(1)
+
+    embedded_before = api.fetch_embedded_workspace_documents()
+    assert embedded_before.count(location) == 1
+
+    # Embed again — should be a no-op
+    embed_new_documents(api, loaded, api.fetch_embedded_workspace_documents())
+    time.sleep(1)
+
+    embedded_after = api.fetch_embedded_workspace_documents()
+    assert embedded_after.count(location) == 1
+
+    api.unembed_document(location)
+    time.sleep(0.5)
+    api.unload_document(location)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,8 +1,14 @@
 """
-Integration tests against a running local AnythingLLM instance.
+Integration tests against a running local AnythingLLM instance (http://localhost:3001).
 
-Requires ~/.anythingllm-sync/config.yaml to be present and AnythingLLM
-to be running at http://localhost:3001.
+Tests are organised into sections:
+  1. fetch_local_documents — purely local logic, no API required
+  2. Database — purely local logic, no API required
+  3. API-level — individual AnythingLLM API methods
+  4. Sync logic (single document)
+  5. Sync logic (multiple documents)
+  6. Sync logic (edge cases)
+  7. Full end-to-end cycle via main()
 
 Run with: pytest tests/test_integration.py -v
 """
@@ -10,22 +16,24 @@ Run with: pytest tests/test_integration.py -v
 import os
 import time
 import pytest
-from pathlib import Path
-from unittest.mock import patch
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
 
 from anythingllm_loader.config import AnythingLLMConfig
 from anythingllm_loader.anythingllm_api import AnythingLLM
 from anythingllm_loader.database import DocumentDatabase, AnythingLLMDocument
 from ingest_anythingllm_docs import (
+    fetch_local_documents,
     upload_new_documents,
     embed_new_documents,
     remove_embedded_documents,
     remove_loaded_documents,
+    main,
 )
 
 
 # ---------------------------------------------------------------------------
-# Fixtures
+# Shared fixtures
 # ---------------------------------------------------------------------------
 
 @pytest.fixture(scope="module")
@@ -45,10 +53,20 @@ def api(config):
 
 @pytest.fixture
 def test_file(tmp_path):
-    """A temporary text file to use as a test document."""
     f = tmp_path / "anythingllm_integration_test.txt"
     f.write_text("This is an integration test document for AnythingLLM.")
     return f
+
+
+@pytest.fixture
+def test_files(tmp_path):
+    """Three temporary text files for multi-document tests."""
+    files = []
+    for i in range(3):
+        f = tmp_path / f"test_doc_{i}.txt"
+        f.write_text(f"Test document {i} for AnythingLLM integration testing.")
+        files.append(f)
+    return files
 
 
 @pytest.fixture
@@ -73,7 +91,179 @@ def uploaded(api, test_file):
 
 
 # ---------------------------------------------------------------------------
-# API-level tests
+# 1. fetch_local_documents (no API required)
+# ---------------------------------------------------------------------------
+
+def _config_for(tmp_path, directory_excludes=None, file_excludes=None):
+    return AnythingLLMConfig(
+        api_key="dummy",
+        file_paths=[str(tmp_path)],
+        directory_excludes=directory_excludes or [],
+        file_excludes=file_excludes or [],
+        workspace_slug="test",
+    )
+
+
+def test_fetch_local_documents_finds_supported_files(tmp_path):
+    (tmp_path / "doc.txt").write_text("content")
+    (tmp_path / "doc.md").write_text("content")
+    (tmp_path / "doc.pdf").write_text("content")
+
+    docs = fetch_local_documents(_config_for(tmp_path))
+
+    assert str(tmp_path / "doc.txt") in docs
+    assert str(tmp_path / "doc.md") in docs
+    assert str(tmp_path / "doc.pdf") in docs
+
+
+def test_fetch_local_documents_excludes_unsupported_types(tmp_path):
+    (tmp_path / "doc.txt").write_text("content")
+    (tmp_path / "doc.xyz").write_text("content")
+    (tmp_path / "doc.csv").write_text("content")
+
+    docs = fetch_local_documents(_config_for(tmp_path))
+
+    assert str(tmp_path / "doc.txt") in docs
+    assert str(tmp_path / "doc.xyz") not in docs
+    assert str(tmp_path / "doc.csv") not in docs
+
+
+def test_fetch_local_documents_scans_subdirectories(tmp_path):
+    subdir = tmp_path / "sub" / "nested"
+    subdir.mkdir(parents=True)
+    (subdir / "deep.txt").write_text("content")
+
+    docs = fetch_local_documents(_config_for(tmp_path))
+
+    assert str(subdir / "deep.txt") in docs
+
+
+def test_fetch_local_documents_excludes_directories(tmp_path):
+    (tmp_path / "included").mkdir()
+    (tmp_path / "excluded_dir").mkdir()
+    (tmp_path / "included" / "doc.txt").write_text("content")
+    (tmp_path / "excluded_dir" / "doc.txt").write_text("content")
+
+    docs = fetch_local_documents(_config_for(tmp_path, directory_excludes=["excluded_dir"]))
+
+    assert str(tmp_path / "included" / "doc.txt") in docs
+    assert str(tmp_path / "excluded_dir" / "doc.txt") not in docs
+
+
+def test_fetch_local_documents_excludes_files(tmp_path):
+    (tmp_path / "keep.txt").write_text("content")
+    (tmp_path / "ignore.txt").write_text("content")
+
+    docs = fetch_local_documents(_config_for(tmp_path, file_excludes=["ignore"]))
+
+    assert str(tmp_path / "keep.txt") in docs
+    assert str(tmp_path / "ignore.txt") not in docs
+
+
+def test_fetch_local_documents_multiple_paths(tmp_path):
+    path1 = tmp_path / "dir1"
+    path2 = tmp_path / "dir2"
+    path1.mkdir()
+    path2.mkdir()
+    (path1 / "doc1.txt").write_text("content")
+    (path2 / "doc2.txt").write_text("content")
+
+    config = AnythingLLMConfig(
+        api_key="dummy",
+        file_paths=[str(path1), str(path2)],
+        directory_excludes=[],
+        file_excludes=[],
+        workspace_slug="test",
+    )
+
+    docs = fetch_local_documents(config)
+
+    assert str(path1 / "doc1.txt") in docs
+    assert str(path2 / "doc2.txt") in docs
+
+
+def test_fetch_local_documents_ignores_directories_as_files(tmp_path):
+    """rglob returns both files and directories — only files should be included."""
+    (tmp_path / "subdir").mkdir()
+    (tmp_path / "doc.txt").write_text("content")
+
+    docs = fetch_local_documents(_config_for(tmp_path))
+
+    assert str(tmp_path / "subdir") not in docs
+    assert str(tmp_path / "doc.txt") in docs
+
+
+# ---------------------------------------------------------------------------
+# 2. Database (no API required)
+# ---------------------------------------------------------------------------
+
+def _make_doc(local_path, location="custom-documents/file.json"):
+    return AnythingLLMDocument(
+        local_path,
+        datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+        location,
+        "{}",
+    )
+
+
+def test_database_starts_empty(db):
+    assert db.get_documents() == []
+
+
+def test_database_add_and_retrieve_document(db):
+    db.add_document(_make_doc("/path/to/file.txt", "custom-documents/file.txt-uuid.json"))
+
+    docs = db.get_documents()
+    assert len(docs) == 1
+    assert docs[0].local_file_path == "/path/to/file.txt"
+    assert docs[0].anythingllm_document_location == "custom-documents/file.txt-uuid.json"
+
+
+def test_database_remove_document_by_local_path(db):
+    db.add_document(_make_doc("/path/to/file.txt"))
+    assert len(db.get_documents()) == 1
+
+    db.remove_document("/path/to/file.txt")
+    assert db.get_documents() == []
+
+
+def test_database_remove_document_ignores_wrong_key(db):
+    """remove_document deletes by local_file_path — passing anythingllm_document_location must not delete the record."""
+    db.add_document(_make_doc("/path/to/file.txt", "custom-documents/file.txt-uuid.json"))
+
+    db.remove_document("custom-documents/file.txt-uuid.json")
+    assert len(db.get_documents()) == 1  # still present
+
+    db.remove_document("/path/to/file.txt")
+    assert db.get_documents() == []
+
+
+def test_database_multiple_documents(db):
+    for i in range(3):
+        db.add_document(_make_doc(f"/path/to/file{i}.txt", f"custom-documents/file{i}.json"))
+
+    docs = db.get_documents()
+    assert len(docs) == 3
+    assert {d.local_file_path for d in docs} == {
+        "/path/to/file0.txt", "/path/to/file1.txt", "/path/to/file2.txt"
+    }
+
+
+def test_database_timestamp_roundtrip(db):
+    original = datetime(2026, 3, 15, 10, 30, 45, tzinfo=timezone.utc)
+    db.add_document(AnythingLLMDocument("/path/file.txt", original, "custom-documents/x.json", "{}"))
+
+    retrieved = db.get_documents()[0].upload_timestamp
+    assert retrieved.year == 2026
+    assert retrieved.month == 3
+    assert retrieved.day == 15
+    assert retrieved.hour == 10
+    assert retrieved.minute == 30
+    assert retrieved.second == 45
+
+
+# ---------------------------------------------------------------------------
+# 3. API-level tests
 # ---------------------------------------------------------------------------
 
 def test_authenticate(api):
@@ -85,7 +275,6 @@ def test_upload_document(api, test_file):
     assert result is not None
     assert "location" in result
     assert result["location"].startswith("custom-documents/")
-
     api.unload_document(result["location"])
 
 
@@ -103,38 +292,11 @@ def test_upload_unsupported_type_returns_none(api, tmp_path):
 
 def test_uploaded_document_appears_in_loaded_list(api, uploaded):
     loaded = api.fetch_loaded_documents_from_anythingllm()
-    # fetch_loaded_documents_from_anythingllm returns filenames without the
-    # custom-documents/ prefix; reconstruct for comparison
     loaded_locations = {f"custom-documents/{name}" for name in loaded}
     assert uploaded["location"] in loaded_locations
 
 
-def test_embed_document(api, uploaded):
-    location = uploaded["location"]
-
-    api.embed_new_document(location)
-    time.sleep(1)
-
-    embedded = api.fetch_embedded_workspace_documents()
-    assert location in embedded
-
-    api.unembed_document(location)
-    time.sleep(0.5)
-
-
-def test_unembed_document(api, uploaded):
-    location = uploaded["location"]
-
-    api.embed_new_document(location)
-    time.sleep(1)
-    assert location in api.fetch_embedded_workspace_documents()
-
-    api.unembed_document(location)
-    time.sleep(1)
-    assert location not in api.fetch_embedded_workspace_documents()
-
-
-def test_unload_document(api, test_file):
+def test_unloaded_document_disappears_from_loaded_list(api, test_file):
     result = api.upload_document(str(test_file))
     assert result is not None
 
@@ -145,14 +307,40 @@ def test_unload_document(api, test_file):
     assert result["location"] not in loaded_locations
 
 
+def test_embed_document(api, uploaded):
+    api.embed_new_document(uploaded["location"])
+    time.sleep(1)
+    assert uploaded["location"] in api.fetch_embedded_workspace_documents()
+    api.unembed_document(uploaded["location"])
+    time.sleep(0.5)
+
+
+def test_unembed_document(api, uploaded):
+    api.embed_new_document(uploaded["location"])
+    time.sleep(1)
+    assert uploaded["location"] in api.fetch_embedded_workspace_documents()
+
+    api.unembed_document(uploaded["location"])
+    time.sleep(1)
+    assert uploaded["location"] not in api.fetch_embedded_workspace_documents()
+
+
+def test_unload_document(api, test_file):
+    result = api.upload_document(str(test_file))
+    assert result is not None
+    assert api.unload_document(result["location"])
+
+    loaded = api.fetch_loaded_documents_from_anythingllm()
+    loaded_locations = {f"custom-documents/{name}" for name in loaded}
+    assert result["location"] not in loaded_locations
+
+
 # ---------------------------------------------------------------------------
-# Sync logic tests
+# 4. Sync logic — single document
 # ---------------------------------------------------------------------------
 
 def test_sync_uploads_new_document(api, db, test_file):
-    local_docs = [str(test_file)]
-
-    upload_new_documents(api, db, local_docs, db.get_documents())
+    upload_new_documents(api, db, [str(test_file)], db.get_documents())
 
     saved = db.get_documents()
     assert len(saved) == 1
@@ -163,43 +351,32 @@ def test_sync_uploads_new_document(api, db, test_file):
 
 
 def test_sync_skips_unchanged_document(api, db, test_file):
-    local_docs = [str(test_file)]
+    upload_new_documents(api, db, [str(test_file)], db.get_documents())
+    original_location = db.get_documents()[0].anythingllm_document_location
 
-    upload_new_documents(api, db, local_docs, db.get_documents())
-    first_upload = db.get_documents()
-    assert len(first_upload) == 1
-    original_location = first_upload[0].anythingllm_document_location
+    upload_new_documents(api, db, [str(test_file)], db.get_documents())
 
-    # Second sync — file unchanged, should not re-upload
-    upload_new_documents(api, db, local_docs, db.get_documents())
-    second_upload = db.get_documents()
-    assert len(second_upload) == 1
-    assert second_upload[0].anythingllm_document_location == original_location
+    saved = db.get_documents()
+    assert len(saved) == 1
+    assert saved[0].anythingllm_document_location == original_location
 
     api.unload_document(original_location)
 
 
 def test_sync_reuploads_modified_document(api, db, test_file):
-    local_docs = [str(test_file)]
+    upload_new_documents(api, db, [str(test_file)], db.get_documents())
+    original_location = db.get_documents()[0].anythingllm_document_location
 
-    # Initial upload
-    upload_new_documents(api, db, local_docs, db.get_documents())
-    saved = db.get_documents()
-    assert len(saved) == 1
-    original_location = saved[0].anythingllm_document_location
-
-    # Modify the file and push its mtime into the future
     test_file.write_text("Modified content.")
     future_mtime = time.time() + 10
     os.utime(test_file, (future_mtime, future_mtime))
 
-    # Second sync — should remove old version and re-upload
-    upload_new_documents(api, db, local_docs, db.get_documents())
+    upload_new_documents(api, db, [str(test_file)], db.get_documents())
+
     saved = db.get_documents()
     assert len(saved) == 1
     assert saved[0].anythingllm_document_location != original_location
 
-    # Original should be gone from AnythingLLM
     loaded = api.fetch_loaded_documents_from_anythingllm()
     loaded_locations = {f"custom-documents/{name}" for name in loaded}
     assert original_location not in loaded_locations
@@ -208,9 +385,7 @@ def test_sync_reuploads_modified_document(api, db, test_file):
 
 
 def test_sync_embeds_loaded_documents(api, db, test_file):
-    local_docs = [str(test_file)]
-
-    upload_new_documents(api, db, local_docs, db.get_documents())
+    upload_new_documents(api, db, [str(test_file)], db.get_documents())
     loaded = db.get_documents()
     location = loaded[0].anythingllm_document_location
 
@@ -224,11 +399,26 @@ def test_sync_embeds_loaded_documents(api, db, test_file):
     api.unload_document(location)
 
 
-def test_sync_removes_document_deleted_locally(api, db, test_file):
-    local_docs = [str(test_file)]
+def test_sync_does_not_embed_already_embedded_document(api, db, test_file):
+    upload_new_documents(api, db, [str(test_file)], db.get_documents())
+    loaded = db.get_documents()
+    location = loaded[0].anythingllm_document_location
 
-    # Upload and embed
-    upload_new_documents(api, db, local_docs, db.get_documents())
+    embed_new_documents(api, loaded, api.fetch_embedded_workspace_documents())
+    time.sleep(1)
+    assert api.fetch_embedded_workspace_documents().count(location) == 1
+
+    embed_new_documents(api, loaded, api.fetch_embedded_workspace_documents())
+    time.sleep(1)
+    assert api.fetch_embedded_workspace_documents().count(location) == 1
+
+    api.unembed_document(location)
+    time.sleep(0.5)
+    api.unload_document(location)
+
+
+def test_sync_removes_document_deleted_locally(api, db, test_file):
+    upload_new_documents(api, db, [str(test_file)], db.get_documents())
     loaded = db.get_documents()
     location = loaded[0].anythingllm_document_location
 
@@ -237,8 +427,7 @@ def test_sync_removes_document_deleted_locally(api, db, test_file):
     assert location in api.fetch_embedded_workspace_documents()
 
     # Simulate local deletion by passing empty local_docs
-    embedded = api.fetch_embedded_workspace_documents()
-    remove_embedded_documents(api, [], db.get_documents(), embedded)
+    remove_embedded_documents(api, [], db.get_documents(), api.fetch_embedded_workspace_documents())
     time.sleep(1)
     assert location not in api.fetch_embedded_workspace_documents()
 
@@ -246,31 +435,244 @@ def test_sync_removes_document_deleted_locally(api, db, test_file):
     assert db.get_documents() == []
 
     loaded_in_llm = api.fetch_loaded_documents_from_anythingllm()
-    loaded_locations = {f"custom-documents/{name}" for name in loaded_in_llm}
-    assert location not in loaded_locations
+    assert location not in {f"custom-documents/{n}" for n in loaded_in_llm}
 
 
-def test_sync_does_not_embed_already_embedded_document(api, db, test_file):
-    local_docs = [str(test_file)]
+# ---------------------------------------------------------------------------
+# 5. Sync logic — multiple documents
+# ---------------------------------------------------------------------------
+
+def test_sync_uploads_multiple_documents(api, db, test_files):
+    local_docs = [str(f) for f in test_files]
 
     upload_new_documents(api, db, local_docs, db.get_documents())
+
+    saved = db.get_documents()
+    assert len(saved) == 3
+    assert {d.local_file_path for d in saved} == set(local_docs)
+
+    for doc in saved:
+        api.unload_document(doc.anythingllm_document_location)
+
+
+def test_sync_embeds_multiple_documents(api, db, test_files):
+    local_docs = [str(f) for f in test_files]
+    upload_new_documents(api, db, local_docs, db.get_documents())
     loaded = db.get_documents()
-    location = loaded[0].anythingllm_document_location
 
-    # Embed once
     embed_new_documents(api, loaded, api.fetch_embedded_workspace_documents())
+    time.sleep(2)
+
+    embedded = api.fetch_embedded_workspace_documents()
+    for doc in loaded:
+        assert doc.anythingllm_document_location in embedded
+
+    for doc in loaded:
+        api.unembed_document(doc.anythingllm_document_location)
+        time.sleep(0.5)
+    for doc in loaded:
+        api.unload_document(doc.anythingllm_document_location)
+
+
+def test_sync_skips_unchanged_among_multiple(api, db, test_files):
+    """After initial upload, a second sync should not re-upload any of the unchanged files."""
+    local_docs = [str(f) for f in test_files]
+    upload_new_documents(api, db, local_docs, db.get_documents())
+    original_locations = {d.local_file_path: d.anythingllm_document_location for d in db.get_documents()}
+
+    upload_new_documents(api, db, local_docs, db.get_documents())
+
+    saved = db.get_documents()
+    assert len(saved) == 3
+    for doc in saved:
+        assert doc.anythingllm_document_location == original_locations[doc.local_file_path]
+
+    for doc in saved:
+        api.unload_document(doc.anythingllm_document_location)
+
+
+def test_sync_removes_only_deleted_among_multiple(api, db, test_files):
+    """When only one of several local files is deleted, only that document should be removed."""
+    local_docs = [str(f) for f in test_files]
+    upload_new_documents(api, db, local_docs, db.get_documents())
+    loaded = db.get_documents()
+
+    embed_new_documents(api, loaded, api.fetch_embedded_workspace_documents())
+    time.sleep(2)
+
+    deleted_path = local_docs[0]
+    deleted_location = next(d.anythingllm_document_location for d in loaded if d.local_file_path == deleted_path)
+    remaining_docs = local_docs[1:]
+
+    remove_embedded_documents(api, remaining_docs, db.get_documents(), api.fetch_embedded_workspace_documents())
+    time.sleep(1)
+    remove_loaded_documents(api, db, remaining_docs, db.get_documents())
+
+    # Deleted doc should be gone
+    assert deleted_location not in api.fetch_embedded_workspace_documents()
+    assert len(db.get_documents()) == 2
+
+    # Remaining docs should still be present
+    embedded = api.fetch_embedded_workspace_documents()
+    for doc in db.get_documents():
+        assert doc.anythingllm_document_location in embedded
+
+    # Cleanup
+    for doc in db.get_documents():
+        api.unembed_document(doc.anythingllm_document_location)
+        time.sleep(0.5)
+    for doc in db.get_documents():
+        api.unload_document(doc.anythingllm_document_location)
+
+
+# ---------------------------------------------------------------------------
+# 6. Sync logic — edge cases
+# ---------------------------------------------------------------------------
+
+def test_remove_embedded_document_not_in_db(api, db, test_file):
+    """
+    A document embedded in the workspace but absent from the local DB should be
+    unembedded. This exercises the `embedded_document_local_path is None` branch
+    (fixed by adding `continue` so the document isn't also added for being 'not found locally').
+    """
+    result = api.upload_document(str(test_file))
+    assert result is not None
+    location = result["location"]
+
+    api.embed_new_document(location)
+    time.sleep(1)
+    assert location in api.fetch_embedded_workspace_documents()
+
+    # DB has no record of this document
+    assert db.get_documents() == []
+
+    remove_embedded_documents(api, [str(test_file)], db.get_documents(), api.fetch_embedded_workspace_documents())
     time.sleep(1)
 
-    embedded_before = api.fetch_embedded_workspace_documents()
-    assert embedded_before.count(location) == 1
-
-    # Embed again — should be a no-op
-    embed_new_documents(api, loaded, api.fetch_embedded_workspace_documents())
-    time.sleep(1)
-
-    embedded_after = api.fetch_embedded_workspace_documents()
-    assert embedded_after.count(location) == 1
-
-    api.unembed_document(location)
-    time.sleep(0.5)
+    assert location not in api.fetch_embedded_workspace_documents()
     api.unload_document(location)
+
+
+def test_remove_embedded_document_not_in_db_not_added_twice(api, db, test_file):
+    """
+    The same document should only appear once in documents_to_unembed even when
+    it is both absent from the DB and absent locally — the `continue` prevents
+    it being appended a second time via the 'not found locally' path.
+    """
+    result = api.upload_document(str(test_file))
+    assert result is not None
+    location = result["location"]
+
+    api.embed_new_document(location)
+    time.sleep(1)
+
+    unembed_calls = []
+    original_unembed = api.unembed_document
+    api.unembed_document = lambda loc: unembed_calls.append(loc) or original_unembed(loc)
+
+    remove_embedded_documents(api, [], db.get_documents(), api.fetch_embedded_workspace_documents())
+    time.sleep(1)
+
+    api.unembed_document = original_unembed
+    assert unembed_calls.count(location) == 1, "unembed_document should be called exactly once per document"
+    api.unload_document(location)
+
+
+def test_sync_ignores_files_not_in_local_docs(api, db, test_files):
+    """upload_new_documents should only process files in local_documents, not all DB entries."""
+    local_docs = [str(f) for f in test_files]
+    upload_new_documents(api, db, local_docs, db.get_documents())
+    assert len(db.get_documents()) == 3
+
+    # Second sync with only the first file — the other two should be untouched
+    upload_new_documents(api, db, [local_docs[0]], db.get_documents())
+    assert len(db.get_documents()) == 3  # still 3 in DB, no re-uploads
+
+    for doc in db.get_documents():
+        api.unload_document(doc.anythingllm_document_location)
+
+
+# ---------------------------------------------------------------------------
+# 7. Full end-to-end cycle via main()
+# ---------------------------------------------------------------------------
+
+def test_main_uploads_and_embeds_configured_files(tmp_path):
+    """
+    Run main() end-to-end with a patched config pointing to a temp directory
+    and an isolated database. Verifies all documents are uploaded and embedded.
+    """
+    doc = tmp_path / "main_test.txt"
+    doc.write_text("Full cycle test document for main().")
+
+    test_config = AnythingLLMConfig(
+        api_key="TRMW9CQ-VK0MG2T-GR2P7SE-8DN7GEA",
+        file_paths=[str(tmp_path)],
+        directory_excludes=[],
+        file_excludes=[],
+        workspace_slug="test",
+    )
+    db_path = tmp_path / "test.db"
+
+    with patch.object(AnythingLLMConfig, "load_config", return_value=test_config), \
+         patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        main()
+
+    client = AnythingLLM(test_config)
+    embedded = client.fetch_embedded_workspace_documents()
+
+    with patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        database = DocumentDatabase()
+        saved = database.get_documents()
+
+    assert len(saved) == 1
+    assert saved[0].anythingllm_document_location in embedded
+
+    # Cleanup
+    client.unembed_document(saved[0].anythingllm_document_location)
+    time.sleep(0.5)
+    client.unload_document(saved[0].anythingllm_document_location)
+
+
+def test_main_removes_deleted_files_on_second_run(tmp_path):
+    """
+    Running main() twice — once with a file present, once without — should
+    result in the document being unembedded and unloaded on the second run.
+    """
+    doc = tmp_path / "ephemeral.txt"
+    doc.write_text("This document will be deleted before the second run.")
+
+    test_config = AnythingLLMConfig(
+        api_key="TRMW9CQ-VK0MG2T-GR2P7SE-8DN7GEA",
+        file_paths=[str(tmp_path)],
+        directory_excludes=[],
+        file_excludes=[],
+        workspace_slug="test",
+    )
+    db_path = tmp_path / "test.db"
+
+    # First run — upload and embed
+    with patch.object(AnythingLLMConfig, "load_config", return_value=test_config), \
+         patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        main()
+
+    with patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        saved = DocumentDatabase().get_documents()
+    assert len(saved) == 1
+    location = saved[0].anythingllm_document_location
+
+    client = AnythingLLM(test_config)
+    time.sleep(1)
+    assert location in client.fetch_embedded_workspace_documents()
+
+    # Delete the file and run again
+    doc.unlink()
+    with patch.object(AnythingLLMConfig, "load_config", return_value=test_config), \
+         patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        main()
+
+    time.sleep(1)
+    assert location not in client.fetch_embedded_workspace_documents()
+    assert location not in {f"custom-documents/{n}" for n in client.fetch_loaded_documents_from_anythingllm()}
+
+    with patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        assert DocumentDatabase().get_documents() == []

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,0 +1,678 @@
+"""
+Unit tests that run without a live AnythingLLM instance.
+All API calls are mocked using unittest.mock.
+
+Run with: pytest tests/test_unit.py -v
+"""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock, call
+
+import requests as requests_lib
+
+from anythingllm_loader.config import AnythingLLMConfig
+from anythingllm_loader.anythingllm_api import AnythingLLM
+from anythingllm_loader.database import DocumentDatabase, AnythingLLMDocument
+from ingest_anythingllm_docs import (
+    fetch_local_documents,
+    upload_new_documents,
+    embed_new_documents,
+    remove_embedded_documents,
+    remove_loaded_documents,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def config():
+    return AnythingLLMConfig(
+        api_key="test-api-key",
+        file_paths=["/test/path"],
+        directory_excludes=[],
+        file_excludes=[],
+        workspace_slug="test-workspace",
+    )
+
+
+@pytest.fixture
+def api(config):
+    return AnythingLLM(config)
+
+
+@pytest.fixture
+def mock_api():
+    return MagicMock(spec=AnythingLLM)
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = tmp_path / "test.db"
+    with patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        database = DocumentDatabase()
+        database.initialize_database()
+        yield database
+
+
+@pytest.fixture
+def test_file(tmp_path):
+    f = tmp_path / "test.txt"
+    f.write_text("Test content")
+    return f
+
+
+def _doc(local_path, location, ts=None):
+    """Helper to create an AnythingLLMDocument with a controllable timestamp."""
+    return AnythingLLMDocument(
+        local_path,
+        ts or datetime(2020, 1, 1, 0, 0, 0),
+        location,
+        "{}",
+    )
+
+
+def _ok_response(body=None):
+    r = MagicMock()
+    r.status_code = 200
+    r.json.return_value = body or {}
+    return r
+
+
+def _error_response(status=500, text="Server error"):
+    r = MagicMock()
+    r.status_code = status
+    r.text = text
+    return r
+
+
+# ---------------------------------------------------------------------------
+# AnythingLLM.authenticate
+# ---------------------------------------------------------------------------
+
+def test_authenticate_returns_true_on_success(api):
+    with patch("requests.get", return_value=_ok_response({"authenticated": True})):
+        assert api.authenticate() is True
+
+
+def test_authenticate_returns_false_on_non_200(api):
+    with patch("requests.get", return_value=_error_response(403)):
+        assert api.authenticate() is False
+
+
+def test_authenticate_returns_false_when_not_authenticated(api):
+    with patch("requests.get", return_value=_ok_response({"authenticated": False})):
+        assert api.authenticate() is False
+
+
+def test_authenticate_sends_api_key_header(api):
+    with patch("requests.get", return_value=_ok_response({"authenticated": True})) as mock_get:
+        api.authenticate()
+    headers = mock_get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer test-api-key"
+
+
+# ---------------------------------------------------------------------------
+# AnythingLLM.supported_file_types
+# ---------------------------------------------------------------------------
+
+def test_supported_file_types_includes_common_text_formats():
+    types = AnythingLLM.supported_file_types()
+    for expected in ["txt", "md", "pdf", "docx", "html"]:
+        assert expected in types
+
+
+def test_supported_file_types_excludes_removed_formats():
+    types = AnythingLLM.supported_file_types()
+    for excluded in ["xlsx", "pptx", "wav", "mp3", "mp4", "csv"]:
+        assert excluded not in types
+
+
+# ---------------------------------------------------------------------------
+# AnythingLLM.upload_document
+# ---------------------------------------------------------------------------
+
+def test_upload_document_returns_first_document_on_success(api, test_file):
+    body = {
+        "success": True,
+        "error": None,
+        "documents": [{"location": "custom-documents/test.txt-uuid.json", "title": "test.txt"}],
+    }
+    with patch("requests.post", return_value=_ok_response(body)):
+        result = api.upload_document(str(test_file))
+    assert result["location"] == "custom-documents/test.txt-uuid.json"
+
+
+def test_upload_document_returns_none_for_empty_file(api, tmp_path):
+    empty = tmp_path / "empty.txt"
+    empty.write_text("")
+    assert api.upload_document(str(empty)) is None
+
+
+def test_upload_document_returns_none_for_unsupported_type(api, tmp_path):
+    f = tmp_path / "file.xyz"
+    f.write_text("content")
+    assert api.upload_document(str(f)) is None
+
+
+def test_upload_document_returns_none_on_non_200(api, test_file):
+    with patch("requests.post", return_value=_error_response(500)):
+        result = api.upload_document(str(test_file))
+    assert result is None
+
+
+def test_upload_document_returns_none_on_api_error_in_body(api, test_file):
+    body = {"success": False, "error": "Processing failed", "documents": []}
+    with patch("requests.post", return_value=_ok_response(body)):
+        result = api.upload_document(str(test_file))
+    assert result is None
+
+
+def test_upload_document_sends_file_as_multipart(api, test_file):
+    body = {
+        "success": True, "error": None,
+        "documents": [{"location": "custom-documents/test.txt-uuid.json"}],
+    }
+    with patch("requests.post", return_value=_ok_response(body)) as mock_post:
+        api.upload_document(str(test_file))
+    assert "files" in mock_post.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# AnythingLLM.fetch_loaded_documents_from_anythingllm
+# ---------------------------------------------------------------------------
+
+def test_fetch_loaded_documents_returns_filenames(api):
+    body = {
+        "localFiles": {
+            "name": "documents", "type": "folder",
+            "items": [
+                {"type": "file", "name": "doc1.txt-uuid.json"},
+                {"type": "file", "name": "doc2.txt-uuid.json"},
+            ],
+        }
+    }
+    with patch("requests.get", return_value=_ok_response(body)):
+        result = api.fetch_loaded_documents_from_anythingllm()
+    assert "doc1.txt-uuid.json" in result
+    assert "doc2.txt-uuid.json" in result
+
+
+def test_fetch_loaded_documents_traverses_nested_folders(api):
+    body = {
+        "localFiles": {
+            "name": "documents", "type": "folder",
+            "items": [
+                {
+                    "type": "folder", "name": "subfolder",
+                    "items": [{"type": "file", "name": "nested.txt-uuid.json"}],
+                },
+                {"type": "file", "name": "top.txt-uuid.json"},
+            ],
+        }
+    }
+    with patch("requests.get", return_value=_ok_response(body)):
+        result = api.fetch_loaded_documents_from_anythingllm()
+    assert "nested.txt-uuid.json" in result
+    assert "top.txt-uuid.json" in result
+
+
+def test_fetch_loaded_documents_returns_empty_list_when_none(api):
+    body = {"localFiles": {"name": "documents", "type": "folder", "items": []}}
+    with patch("requests.get", return_value=_ok_response(body)):
+        result = api.fetch_loaded_documents_from_anythingllm()
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# AnythingLLM.fetch_embedded_workspace_documents
+# ---------------------------------------------------------------------------
+
+def test_fetch_embedded_workspace_documents_returns_docpaths(api):
+    body = {"workspace": [{"documents": [
+        {"docpath": "custom-documents/doc1.json"},
+        {"docpath": "custom-documents/doc2.json"},
+    ]}]}
+    with patch("requests.get", return_value=_ok_response(body)):
+        result = api.fetch_embedded_workspace_documents()
+    assert "custom-documents/doc1.json" in result
+    assert "custom-documents/doc2.json" in result
+
+
+def test_fetch_embedded_workspace_documents_deduplicates(api):
+    body = {"workspace": [{"documents": [
+        {"docpath": "custom-documents/doc.json"},
+        {"docpath": "custom-documents/doc.json"},
+    ]}]}
+    with patch("requests.get", return_value=_ok_response(body)):
+        result = api.fetch_embedded_workspace_documents()
+    assert result.count("custom-documents/doc.json") == 1
+
+
+def test_fetch_embedded_workspace_documents_uses_workspace_slug(api):
+    body = {"workspace": [{"documents": []}]}
+    with patch("requests.get", return_value=_ok_response(body)) as mock_get:
+        api.fetch_embedded_workspace_documents()
+    assert "test-workspace" in mock_get.call_args.args[0]
+
+
+# ---------------------------------------------------------------------------
+# AnythingLLM.embed_new_document
+# ---------------------------------------------------------------------------
+
+def test_embed_new_document_posts_to_correct_endpoint(api):
+    with patch("requests.post", return_value=_ok_response({"workspace": {}})) as mock_post, \
+         patch("time.sleep"):
+        api.embed_new_document("custom-documents/doc.txt-uuid.json")
+    url = mock_post.call_args.args[0]
+    assert "/api/v1/workspace/test-workspace/update-embeddings" in url
+
+
+def test_embed_new_document_sends_adds_key(api):
+    with patch("requests.post", return_value=_ok_response({"workspace": {}})) as mock_post, \
+         patch("time.sleep"):
+        api.embed_new_document("custom-documents/doc.txt-uuid.json")
+    assert mock_post.call_args.kwargs["json"]["adds"] == ["custom-documents/doc.txt-uuid.json"]
+
+
+def test_embed_new_document_sleeps_after_success(api):
+    with patch("requests.post", return_value=_ok_response({"workspace": {}})), \
+         patch("time.sleep") as mock_sleep:
+        api.embed_new_document("custom-documents/doc.txt-uuid.json")
+    mock_sleep.assert_called_once_with(0.5)
+
+
+def test_embed_new_document_handles_exception_without_raising(api):
+    with patch("requests.post", side_effect=requests_lib.exceptions.ReadTimeout("timed out")):
+        # Should catch and print, not raise
+        api.embed_new_document("custom-documents/doc.txt-uuid.json")
+
+
+def test_embed_new_document_does_not_sleep_on_error(api):
+    with patch("requests.post", return_value=_error_response(500)), \
+         patch("time.sleep") as mock_sleep:
+        api.embed_new_document("custom-documents/doc.txt-uuid.json")
+    mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AnythingLLM.unload_document
+# ---------------------------------------------------------------------------
+
+def test_unload_document_uses_delete_method(api):
+    with patch("requests.delete", return_value=_ok_response()) as mock_delete:
+        api.unload_document("custom-documents/doc.txt-uuid.json")
+    mock_delete.assert_called_once()
+
+
+def test_unload_document_sends_names_key(api):
+    with patch("requests.delete", return_value=_ok_response()) as mock_delete:
+        api.unload_document("custom-documents/doc.txt-uuid.json")
+    assert "names" in mock_delete.call_args.kwargs["json"]
+    assert "deletes" not in mock_delete.call_args.kwargs["json"]
+
+
+def test_unload_document_returns_true_on_success(api):
+    with patch("requests.delete", return_value=_ok_response()):
+        assert api.unload_document("custom-documents/doc.txt-uuid.json") is True
+
+
+def test_unload_document_returns_false_on_non_200(api):
+    with patch("requests.delete", return_value=_error_response(500)):
+        assert api.unload_document("custom-documents/doc.txt-uuid.json") is False
+
+
+def test_unload_document_includes_api_prefix_in_url(api):
+    with patch("requests.delete", return_value=_ok_response()) as mock_delete:
+        api.unload_document("custom-documents/doc.txt-uuid.json")
+    url = mock_delete.call_args.args[0]
+    assert "/api/v1/system/remove-documents" in url
+
+
+# ---------------------------------------------------------------------------
+# AnythingLLM.unembed_document
+# ---------------------------------------------------------------------------
+
+def test_unembed_document_posts_to_workspace_endpoint(api):
+    with patch("requests.post", return_value=_ok_response()) as mock_post:
+        api.unembed_document("custom-documents/doc.txt-uuid.json")
+    url = mock_post.call_args.args[0]
+    assert "/api/v1/workspace/test-workspace/update-embeddings" in url
+
+
+def test_unembed_document_sends_deletes_key(api):
+    with patch("requests.post", return_value=_ok_response()) as mock_post:
+        api.unembed_document("custom-documents/doc.txt-uuid.json")
+    assert mock_post.call_args.kwargs["json"]["deletes"] == ["custom-documents/doc.txt-uuid.json"]
+
+
+def test_unembed_document_url_has_slash_before_slug(api):
+    """Regression: URL was missing '/' before workspace slug."""
+    with patch("requests.post", return_value=_ok_response()) as mock_post:
+        api.unembed_document("custom-documents/doc.txt-uuid.json")
+    url = mock_post.call_args.args[0]
+    assert "/workspace/test-workspace/" in url
+
+
+# ---------------------------------------------------------------------------
+# upload_new_documents
+# ---------------------------------------------------------------------------
+
+def test_upload_new_documents_uploads_new_file(mock_api, db, test_file):
+    mock_api.upload_document.return_value = {"location": "custom-documents/test.json", "title": "test.txt"}
+    upload_new_documents(mock_api, db, [str(test_file)], [])
+    mock_api.upload_document.assert_called_once_with(str(test_file))
+    assert len(db.get_documents()) == 1
+
+
+def test_upload_new_documents_skips_unchanged_file(mock_api, db, test_file):
+    # Timestamp far in the future → file appears older than the DB record
+    existing = _doc(str(test_file), "custom-documents/existing.json", datetime(2099, 1, 1))
+    db.add_document(existing)
+    upload_new_documents(mock_api, db, [str(test_file)], db.get_documents())
+    mock_api.upload_document.assert_not_called()
+    assert len(db.get_documents()) == 1
+
+
+def test_upload_new_documents_reuploads_modified_file(mock_api, db, test_file):
+    existing = _doc(str(test_file), "custom-documents/old.json", datetime(2000, 1, 1))
+    db.add_document(existing)
+    mock_api.unload_document.return_value = True
+    mock_api.upload_document.return_value = {"location": "custom-documents/new.json", "title": "test.txt"}
+
+    upload_new_documents(mock_api, db, [str(test_file)], db.get_documents())
+
+    mock_api.unload_document.assert_called_once_with("custom-documents/old.json")
+    mock_api.upload_document.assert_called_once()
+    saved = db.get_documents()
+    assert len(saved) == 1
+    assert saved[0].anythingllm_document_location == "custom-documents/new.json"
+
+
+def test_upload_new_documents_reuploads_even_when_unload_fails(mock_api, db, test_file):
+    """document_loaded = False when unload fails, so upload is still attempted."""
+    existing = _doc(str(test_file), "custom-documents/old.json", datetime(2000, 1, 1))
+    db.add_document(existing)
+    mock_api.unload_document.return_value = False
+    mock_api.upload_document.return_value = {"location": "custom-documents/new.json", "title": "test.txt"}
+
+    upload_new_documents(mock_api, db, [str(test_file)], db.get_documents())
+
+    mock_api.upload_document.assert_called_once()
+
+
+def test_upload_new_documents_does_not_save_to_db_on_upload_failure(mock_api, db, test_file):
+    mock_api.upload_document.return_value = None
+    upload_new_documents(mock_api, db, [str(test_file)], [])
+    assert db.get_documents() == []
+
+
+def test_upload_new_documents_handles_empty_local_docs(mock_api, db):
+    upload_new_documents(mock_api, db, [], [])
+    mock_api.upload_document.assert_not_called()
+
+
+def test_upload_new_documents_uploads_all_new_files(mock_api, db, tmp_path):
+    files = []
+    for i in range(3):
+        f = tmp_path / f"doc{i}.txt"
+        f.write_text(f"content {i}")
+        files.append(str(f))
+    mock_api.upload_document.side_effect = [
+        {"location": f"custom-documents/doc{i}.json", "title": f"doc{i}.txt"} for i in range(3)
+    ]
+    upload_new_documents(mock_api, db, files, [])
+    assert mock_api.upload_document.call_count == 3
+    assert len(db.get_documents()) == 3
+
+
+# ---------------------------------------------------------------------------
+# embed_new_documents
+# ---------------------------------------------------------------------------
+
+def test_embed_new_documents_embeds_unembedded_document(mock_api):
+    doc = _doc("/path/doc.txt", "custom-documents/doc.json")
+    embed_new_documents(mock_api, [doc], [])
+    mock_api.embed_new_document.assert_called_once_with("custom-documents/doc.json")
+
+
+def test_embed_new_documents_skips_already_embedded(mock_api):
+    doc = _doc("/path/doc.txt", "custom-documents/doc.json")
+    embed_new_documents(mock_api, [doc], ["custom-documents/doc.json"])
+    mock_api.embed_new_document.assert_not_called()
+
+
+def test_embed_new_documents_only_embeds_missing_ones(mock_api):
+    doc1 = _doc("/path/doc1.txt", "custom-documents/doc1.json")
+    doc2 = _doc("/path/doc2.txt", "custom-documents/doc2.json")
+    doc3 = _doc("/path/doc3.txt", "custom-documents/doc3.json")
+    already_embedded = ["custom-documents/doc1.json", "custom-documents/doc3.json"]
+
+    embed_new_documents(mock_api, [doc1, doc2, doc3], already_embedded)
+
+    mock_api.embed_new_document.assert_called_once_with("custom-documents/doc2.json")
+
+
+def test_embed_new_documents_handles_empty_inputs(mock_api):
+    embed_new_documents(mock_api, [], [])
+    mock_api.embed_new_document.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# remove_embedded_documents
+# ---------------------------------------------------------------------------
+
+def test_remove_embedded_unembeds_doc_not_in_db(mock_api):
+    remove_embedded_documents(mock_api, [], [], ["custom-documents/orphan.json"])
+    mock_api.unembed_document.assert_called_once_with("custom-documents/orphan.json")
+
+
+def test_remove_embedded_doc_not_in_db_unembedded_exactly_once(mock_api):
+    """Regression: the continue fix prevents double-appending to documents_to_unembed."""
+    calls = []
+    mock_api.unembed_document.side_effect = lambda loc: calls.append(loc)
+    remove_embedded_documents(mock_api, [], [], ["custom-documents/orphan.json"])
+    assert calls.count("custom-documents/orphan.json") == 1
+
+
+def test_remove_embedded_unembeds_doc_not_present_locally(mock_api):
+    doc = _doc("/path/deleted.txt", "custom-documents/deleted.json")
+    remove_embedded_documents(mock_api, [], [doc], ["custom-documents/deleted.json"])
+    mock_api.unembed_document.assert_called_once_with("custom-documents/deleted.json")
+
+
+def test_remove_embedded_keeps_doc_present_locally(mock_api):
+    doc = _doc("/path/kept.txt", "custom-documents/kept.json")
+    remove_embedded_documents(mock_api, ["/path/kept.txt"], [doc], ["custom-documents/kept.json"])
+    mock_api.unembed_document.assert_not_called()
+
+
+def test_remove_embedded_mixed_documents(mock_api):
+    kept = _doc("/path/kept.txt", "custom-documents/kept.json")
+    deleted = _doc("/path/deleted.txt", "custom-documents/deleted.json")
+    embedded = ["custom-documents/kept.json", "custom-documents/deleted.json"]
+
+    remove_embedded_documents(mock_api, ["/path/kept.txt"], [kept, deleted], embedded)
+
+    mock_api.unembed_document.assert_called_once_with("custom-documents/deleted.json")
+
+
+def test_remove_embedded_handles_empty_inputs(mock_api):
+    remove_embedded_documents(mock_api, [], [], [])
+    mock_api.unembed_document.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# remove_loaded_documents
+# ---------------------------------------------------------------------------
+
+def test_remove_loaded_unloads_and_removes_from_db(mock_api, db):
+    doc = _doc("/path/gone.txt", "custom-documents/gone.json")
+    db.add_document(doc)
+    mock_api.unload_document.return_value = True
+
+    remove_loaded_documents(mock_api, db, [], [doc])
+
+    mock_api.unload_document.assert_called_once_with("custom-documents/gone.json")
+    assert db.get_documents() == []
+
+
+def test_remove_loaded_keeps_locally_present_document(mock_api, db):
+    doc = _doc("/path/kept.txt", "custom-documents/kept.json")
+    db.add_document(doc)
+
+    remove_loaded_documents(mock_api, db, ["/path/kept.txt"], [doc])
+
+    mock_api.unload_document.assert_not_called()
+    assert len(db.get_documents()) == 1
+
+
+def test_remove_loaded_does_not_remove_from_db_when_unload_fails(mock_api, db):
+    """DB record must be preserved if the API unload call fails."""
+    doc = _doc("/path/gone.txt", "custom-documents/gone.json")
+    db.add_document(doc)
+    mock_api.unload_document.return_value = False
+
+    remove_loaded_documents(mock_api, db, [], [doc])
+
+    assert len(db.get_documents()) == 1
+
+
+def test_remove_loaded_uses_local_file_path_for_db_removal(mock_api, db):
+    """Regression: remove_document must be called with local_file_path, not anythingllm_document_location."""
+    doc = _doc("/path/gone.txt", "custom-documents/gone.json")
+    db.add_document(doc)
+    mock_api.unload_document.return_value = True
+
+    remove_loaded_documents(mock_api, db, [], [doc])
+
+    # If the bug were present (passing anythingllm_document_location), the record would survive
+    assert db.get_documents() == []
+
+
+def test_remove_loaded_mixed_documents(mock_api, db):
+    kept = _doc("/path/kept.txt", "custom-documents/kept.json")
+    gone = _doc("/path/gone.txt", "custom-documents/gone.json")
+    db.add_document(kept)
+    db.add_document(gone)
+    mock_api.unload_document.return_value = True
+
+    remove_loaded_documents(mock_api, db, ["/path/kept.txt"], [kept, gone])
+
+    mock_api.unload_document.assert_called_once_with("custom-documents/gone.json")
+    remaining = db.get_documents()
+    assert len(remaining) == 1
+    assert remaining[0].local_file_path == "/path/kept.txt"
+
+
+def test_remove_loaded_handles_empty_inputs(mock_api, db):
+    remove_loaded_documents(mock_api, db, [], [])
+    mock_api.unload_document.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+def test_main_exits_early_on_auth_failure(tmp_path):
+    mock_api_instance = MagicMock()
+    mock_api_instance.authenticate.return_value = False
+    test_config = AnythingLLMConfig("key", [str(tmp_path)], [], [], "slug")
+    db_path = tmp_path / "test.db"
+
+    with patch.object(AnythingLLMConfig, "load_config", return_value=test_config), \
+         patch("ingest_anythingllm_docs.AnythingLLM", return_value=mock_api_instance), \
+         patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        main()
+
+    mock_api_instance.upload_document.assert_not_called()
+    mock_api_instance.embed_new_document.assert_not_called()
+
+
+def test_main_exits_early_on_db_init_failure(tmp_path):
+    mock_api_instance = MagicMock()
+    mock_api_instance.authenticate.return_value = True
+    test_config = AnythingLLMConfig("key", [str(tmp_path)], [], [], "slug")
+    db_path = tmp_path / "test.db"
+
+    with patch.object(AnythingLLMConfig, "load_config", return_value=test_config), \
+         patch("ingest_anythingllm_docs.AnythingLLM", return_value=mock_api_instance), \
+         patch("anythingllm_loader.database.DATABASE_FILENAME", db_path), \
+         patch.object(DocumentDatabase, "initialize_database", return_value=False):
+        main()
+
+    mock_api_instance.upload_document.assert_not_called()
+
+
+def _patch_api_class(mock_api_instance):
+    """
+    Return a configured mock for the AnythingLLM class itself (not just an instance).
+    supported_file_types() must return the real list so fetch_local_documents works correctly —
+    MagicMock's __contains__ defaults to False, which would cause every file to appear unsupported.
+    """
+    mock_class = MagicMock()
+    mock_class.return_value = mock_api_instance
+    mock_class.supported_file_types.return_value = AnythingLLM.supported_file_types()
+    return mock_class
+
+
+def test_main_uploads_and_embeds_documents(tmp_path):
+    doc = tmp_path / "test.txt"
+    doc.write_text("content")
+    test_config = AnythingLLMConfig("key", [str(tmp_path)], [], [], "slug")
+    db_path = tmp_path / "test.db"
+
+    mock_api_instance = MagicMock()
+    mock_api_instance.authenticate.return_value = True
+    mock_api_instance.upload_document.return_value = {
+        "location": "custom-documents/test.txt-uuid.json",
+        "title": "test.txt",
+    }
+    mock_api_instance.fetch_embedded_workspace_documents.return_value = []
+
+    with patch.object(AnythingLLMConfig, "load_config", return_value=test_config), \
+         patch("ingest_anythingllm_docs.AnythingLLM", _patch_api_class(mock_api_instance)), \
+         patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        main()
+
+    mock_api_instance.upload_document.assert_called_once()
+    mock_api_instance.embed_new_document.assert_called_once_with("custom-documents/test.txt-uuid.json")
+
+
+def test_main_does_not_upload_unsupported_files(tmp_path):
+    (tmp_path / "file.csv").write_text("a,b,c")
+    (tmp_path / "file.xyz").write_text("content")
+    test_config = AnythingLLMConfig("key", [str(tmp_path)], [], [], "slug")
+    db_path = tmp_path / "test.db"
+
+    mock_api_instance = MagicMock()
+    mock_api_instance.authenticate.return_value = True
+    mock_api_instance.fetch_embedded_workspace_documents.return_value = []
+
+    with patch.object(AnythingLLMConfig, "load_config", return_value=test_config), \
+         patch("ingest_anythingllm_docs.AnythingLLM", _patch_api_class(mock_api_instance)), \
+         patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        main()
+
+    mock_api_instance.upload_document.assert_not_called()
+
+
+def test_main_removes_embedded_docs_missing_locally(tmp_path):
+    test_config = AnythingLLMConfig("key", [str(tmp_path)], [], [], "slug")
+    db_path = tmp_path / "test.db"
+
+    mock_api_instance = MagicMock()
+    mock_api_instance.authenticate.return_value = True
+    mock_api_instance.fetch_embedded_workspace_documents.return_value = [
+        "custom-documents/orphan.json"
+    ]
+
+    with patch.object(AnythingLLMConfig, "load_config", return_value=test_config), \
+         patch("ingest_anythingllm_docs.AnythingLLM", _patch_api_class(mock_api_instance)), \
+         patch("anythingllm_loader.database.DATABASE_FILENAME", db_path):
+        main()
+
+    mock_api_instance.unembed_document.assert_called_with("custom-documents/orphan.json")


### PR DESCRIPTION
## Summary

- **Bug fixes from PR #3**: corrected HTTP method, URL, and payload key in `unload_document`; fixed missing `/` in `unembed_document` URL; fixed `remove_loaded_documents` passing wrong argument to `database.remove_document`
- **Regression fix**: `document_loaded` was incorrectly set to `False` in the file-unchanged branch of `upload_new_documents`, causing every already-loaded file to be re-uploaded on every run
- **Additional bug fixes**: file handle leak in `upload_document`, missing exception handling in `unload_document`/`unembed_document`, `UnboundLocalError` risk in `initialize_database`, O(n²) nested loops replaced with dict/set lookups, dead xlsx special-case code removed
- **Tests**: 37 integration tests (requires live AnythingLLM) and 59 unit tests (fully mocked, no instance needed)
- **Docs**: `CLAUDE.md` created; `README.md` rewritten to reflect current state

## Test plan

- [ ] Run unit tests (no AnythingLLM required): `pytest tests/test_unit.py -v`
- [ ] Run integration tests (requires AnythingLLM at localhost:3001): `pytest tests/test_integration.py -v`
- [ ] Run a manual sync and verify documents are uploaded, embedded, and cleaned up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)