### PR TITLE
feat: make AnythingLLM URL configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Requires `~/.anythingllm-sync/config.yaml`:
 ```yaml
 api-key: <key>
 workspace-slug: <slug>
+anythingllm-url: http://localhost:3001  # optional, defaults to http://localhost:3001
 file-paths:
   - /path/to/documents/
 directory-excludes:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Create `~/.anythingllm-sync/config.yaml`:
 ```yaml
 api-key: YOUR-API-KEY
 workspace-slug: your-workspace
+anythingllm-url: http://localhost:3001  # optional, defaults to http://localhost:3001
 file-paths:
   - /Users/username/Documents/
 directory-excludes:
@@ -51,6 +52,8 @@ file-excludes:
 **API key**: AnythingLLM Desktop → spanner icon (bottom right) → Developer API → Generate New API Key
 
 **Workspace slug**: Click workspace → settings cog → Vector Database tab → Vector database identifier
+
+**AnythingLLM URL**: Set `anythingllm-url` if your instance is not at `http://localhost:3001` — e.g. a Docker container on a custom port: `http://localhost:8080`
 
 ## Usage
 
@@ -76,7 +79,7 @@ Document upload state is tracked in `~/.anythingllm-sync/uploaded-docs.db` (SQLi
 pytest tests/test_unit.py -v
 ```
 
-**Integration tests** (requires AnythingLLM running at `http://localhost:3001` and a valid `~/.anythingllm-sync/config.yaml`):
+**Integration tests** (requires AnythingLLM running and a valid `~/.anythingllm-sync/config.yaml`):
 
 ```shell
 pytest tests/test_integration.py -v

--- a/anythingllm_loader/anythingllm_api.py
+++ b/anythingllm_loader/anythingllm_api.py
@@ -13,6 +13,7 @@ class AnythingLLM:
 
     def __init__(self, config: AnythingLLMConfig):
         self.config = config
+        self._base_url = config.anythingllm_url
 
     # Authenticate with local AnythingLLM API
     # curl -X 'GET' \
@@ -20,7 +21,7 @@ class AnythingLLM:
     #   -H 'accept: application/json' \
     #   -H 'Authorization: Bearer $api-key
     def authenticate(self):
-        response = requests.get('http://localhost:3001/api/v1/auth', headers={
+        response = requests.get(f'{self._base_url}/api/v1/auth', headers={
             'accept': 'application/json',
             'Authorization': 'Bearer ' + self.config.api_key
         })
@@ -48,7 +49,7 @@ class AnythingLLM:
 
         try:
             with open(local_document_path, 'rb') as f:
-                response: Response = requests.post('http://localhost:3001/api/v1/document/upload', headers={
+                response: Response = requests.post(f'{self._base_url}/api/v1/document/upload', headers={
                     'accept': 'application/json',
                     'Authorization': 'Bearer ' + self.config.api_key
                 }, files={
@@ -100,7 +101,7 @@ class AnythingLLM:
     #   -H 'accept: application/json'
     #   -H 'Authorization: Bearer $api-key
     def fetch_loaded_documents_from_anythingllm(self):
-        response = requests.get('http://localhost:3001/api/v1/documents', headers={
+        response = requests.get(f'{self._base_url}/api/v1/documents', headers={
             'accept': 'application/json',
             'Authorization': 'Bearer ' + self.config.api_key
         })
@@ -163,7 +164,7 @@ class AnythingLLM:
 
         # Delete the document.
         try:
-            response: Response = requests.delete('http://localhost:3001/api/v1/system/remove-documents',
+            response: Response = requests.delete(f'{self._base_url}/api/v1/system/remove-documents',
                                                headers={
                                                    'accept': 'application/json',
                                                    'Content-Type': 'application/json',
@@ -200,7 +201,7 @@ class AnythingLLM:
         # Embed the documents
         try:
             response: Response = requests.post(
-                'http://localhost:3001/api/v1/workspace/' + self.config.workspace_slug + '/update-embeddings',
+                f'{self._base_url}/api/v1/workspace/{self.config.workspace_slug}/update-embeddings',
                 headers={
                     'accept': 'application/json',
                     'Content-Type': 'application/json',
@@ -250,7 +251,7 @@ class AnythingLLM:
 
     # Fetch all documents which have been embedded into the workspace
     def fetch_embedded_workspace_documents(self):
-        response = requests.get('http://localhost:3001/api/v1/workspace/' + self.config.workspace_slug, headers={
+        response = requests.get(f'{self._base_url}/api/v1/workspace/{self.config.workspace_slug}', headers={
             'accept': 'application/json',
             'Authorization': 'Bearer ' + self.config.api_key
         })
@@ -311,7 +312,7 @@ class AnythingLLM:
         # Embed the documents
         try:
             response: Response = requests.post(
-                'http://localhost:3001/api/v1/workspace/' + self.config.workspace_slug + '/update-embeddings',
+                f'{self._base_url}/api/v1/workspace/{self.config.workspace_slug}/update-embeddings',
                 headers={
                     'accept': 'application/json',
                     'Content-Type': 'application/json',

--- a/anythingllm_loader/anythingllm_api.py
+++ b/anythingllm_loader/anythingllm_api.py
@@ -13,7 +13,6 @@ class AnythingLLM:
 
     def __init__(self, config: AnythingLLMConfig):
         self.config = config
-        self._base_url = config.anythingllm_url
 
     # Authenticate with local AnythingLLM API
     # curl -X 'GET' \
@@ -21,7 +20,7 @@ class AnythingLLM:
     #   -H 'accept: application/json' \
     #   -H 'Authorization: Bearer $api-key
     def authenticate(self):
-        response = requests.get(f'{self._base_url}/api/v1/auth', headers={
+        response = requests.get(f'{self.config.anythingllm_url}/api/v1/auth', headers={
             'accept': 'application/json',
             'Authorization': 'Bearer ' + self.config.api_key
         })
@@ -49,7 +48,7 @@ class AnythingLLM:
 
         try:
             with open(local_document_path, 'rb') as f:
-                response: Response = requests.post(f'{self._base_url}/api/v1/document/upload', headers={
+                response: Response = requests.post(f'{self.config.anythingllm_url}/api/v1/document/upload', headers={
                     'accept': 'application/json',
                     'Authorization': 'Bearer ' + self.config.api_key
                 }, files={
@@ -101,7 +100,7 @@ class AnythingLLM:
     #   -H 'accept: application/json'
     #   -H 'Authorization: Bearer $api-key
     def fetch_loaded_documents_from_anythingllm(self):
-        response = requests.get(f'{self._base_url}/api/v1/documents', headers={
+        response = requests.get(f'{self.config.anythingllm_url}/api/v1/documents', headers={
             'accept': 'application/json',
             'Authorization': 'Bearer ' + self.config.api_key
         })
@@ -164,7 +163,7 @@ class AnythingLLM:
 
         # Delete the document.
         try:
-            response: Response = requests.delete(f'{self._base_url}/api/v1/system/remove-documents',
+            response: Response = requests.delete(f'{self.config.anythingllm_url}/api/v1/system/remove-documents',
                                                headers={
                                                    'accept': 'application/json',
                                                    'Content-Type': 'application/json',
@@ -201,7 +200,7 @@ class AnythingLLM:
         # Embed the documents
         try:
             response: Response = requests.post(
-                f'{self._base_url}/api/v1/workspace/{self.config.workspace_slug}/update-embeddings',
+                f'{self.config.anythingllm_url}/api/v1/workspace/{self.config.workspace_slug}/update-embeddings',
                 headers={
                     'accept': 'application/json',
                     'Content-Type': 'application/json',
@@ -251,7 +250,7 @@ class AnythingLLM:
 
     # Fetch all documents which have been embedded into the workspace
     def fetch_embedded_workspace_documents(self):
-        response = requests.get(f'{self._base_url}/api/v1/workspace/{self.config.workspace_slug}', headers={
+        response = requests.get(f'{self.config.anythingllm_url}/api/v1/workspace/{self.config.workspace_slug}', headers={
             'accept': 'application/json',
             'Authorization': 'Bearer ' + self.config.api_key
         })
@@ -312,7 +311,7 @@ class AnythingLLM:
         # Embed the documents
         try:
             response: Response = requests.post(
-                f'{self._base_url}/api/v1/workspace/{self.config.workspace_slug}/update-embeddings',
+                f'{self.config.anythingllm_url}/api/v1/workspace/{self.config.workspace_slug}/update-embeddings',
                 headers={
                     'accept': 'application/json',
                     'Content-Type': 'application/json',

--- a/anythingllm_loader/config.py
+++ b/anythingllm_loader/config.py
@@ -6,9 +6,12 @@ CONFIG_DIR = pathlib.Path.home() / ".anythingllm-sync"
 CONFIG_FILE = 'config.yaml'
 
 
+DEFAULT_URL = "http://localhost:3001"
+
 # Config file looks like this:
 # api-key: WFSDFD-ASDAFDFD-Q8M53TR-AAAAS48
 # workspace-slug: aws
+# anythingllm-url: http://localhost:3001   # optional, defaults to http://localhost:3001
 # file-paths:
 #   - /Users/username/Documents/
 # directory-excludes:
@@ -19,12 +22,14 @@ CONFIG_FILE = 'config.yaml'
 class AnythingLLMConfig:
 
     # create init method including all config keys
-    def __init__(self, api_key: str, file_paths: list, directory_excludes: list, file_excludes: list, workspace_slug: str):
+    def __init__(self, api_key: str, file_paths: list, directory_excludes: list, file_excludes: list,
+                 workspace_slug: str, anythingllm_url: str = DEFAULT_URL):
         self.api_key = api_key
         self.file_paths = file_paths
         self.directory_excludes = directory_excludes
         self.file_excludes = file_excludes
         self.workspace_slug = workspace_slug
+        self.anythingllm_url = anythingllm_url.rstrip("/")
 
     @staticmethod
     def load_config():
@@ -50,4 +55,5 @@ class AnythingLLMConfig:
             raise FileNotFoundError(str(CONFIG_DIR) + "/" + CONFIG_FILE + " file not found")
 
         return AnythingLLMConfig(config["api-key"], config["file-paths"], config["directory-excludes"],
-                                 config["file-excludes"], config["workspace-slug"])
+                                 config["file-excludes"], config["workspace-slug"],
+                                 config.get("anythingllm-url", DEFAULT_URL))

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -115,6 +115,31 @@ def test_authenticate_sends_api_key_header(api):
     assert headers["Authorization"] == "Bearer test-api-key"
 
 
+def test_authenticate_uses_default_url(api):
+    with patch("requests.get", return_value=_ok_response({"authenticated": True})) as mock_get:
+        api.authenticate()
+    assert mock_get.call_args.args[0] == "http://localhost:3001/api/v1/auth"
+
+
+def test_authenticate_uses_custom_url():
+    custom_config = AnythingLLMConfig(
+        api_key="key", file_paths=[], directory_excludes=[], file_excludes=[],
+        workspace_slug="slug", anythingllm_url="http://myserver:8080"
+    )
+    api = AnythingLLM(custom_config)
+    with patch("requests.get", return_value=_ok_response({"authenticated": True})) as mock_get:
+        api.authenticate()
+    assert mock_get.call_args.args[0] == "http://myserver:8080/api/v1/auth"
+
+
+def test_custom_url_trailing_slash_stripped():
+    config = AnythingLLMConfig(
+        api_key="key", file_paths=[], directory_excludes=[], file_excludes=[],
+        workspace_slug="slug", anythingllm_url="http://myserver:8080/"
+    )
+    assert config.anythingllm_url == "http://myserver:8080"
+
+
 # ---------------------------------------------------------------------------
 # AnythingLLM.supported_file_types
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds optional `anythingllm-url` key to `~/.anythingllm-sync/config.yaml`, defaulting to `http://localhost:3001`
- Removes all hardcoded URLs from `anythingllm_api.py`, replaced with `self.config.anythingllm_url`
- Trailing slash on the URL is stripped automatically
- Closes #1

## Test plan

- [ ] `pytest tests/test_unit.py -v` — 62 tests pass
- [ ] `pytest tests/test_integration.py -v` — 37 tests pass
- [ ] Manually verify sync works against a non-default URL by setting `anythingllm-url` in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)